### PR TITLE
Split compiler into `SpirvParser`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 language: rust
 rust:
   - stable
-  - beta
-  - nightly
 cache:
   cargo: true
   directories:
    - $HOME/deps
 os: osx
 matrix:
-  allow_failures:
-    - rust: nightly
   include:
     - os: linux
       env: COMPILER_NAME=gcc CXX=g++-5 CC=gcc-5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,17 +3,13 @@ environment:
     RUST_VERSION: stable
     CRATE_NAME: spirv_cross
   matrix:
-    - TARGET: i686-pc-windows-gnu
     - TARGET: x86_64-pc-windows-gnu
-    - TARGET: i686-pc-windows-msvc
     - TARGET: x86_64-pc-windows-msvc
 
 install:
   - ps: >-
       If ($Env:TARGET -eq 'x86_64-pc-windows-gnu') {
         $Env:PATH += ';C:\msys64\mingw64\bin'
-      } ElseIf ($Env:TARGET -eq 'i686-pc-windows-gnu') {
-        $Env:PATH += ';C:\msys64\mingw32\bin'
       }
   - git submodule update --init --recursive
   - curl -sSf -o rustup-init.exe https://win.rustup.rs/

--- a/examples/src/hlsl/main.rs
+++ b/examples/src/hlsl/main.rs
@@ -1,6 +1,7 @@
 extern crate spirv_cross;
-use spirv_cross::{CompileTarget, HlslCompiler, HlslCompilerOptions, SpirvModule, SpirvParser,
-                  SpirvParserOptions};
+use spirv_cross::spirv;
+use spirv_cross::hlsl;
+use spirv_cross::CompileTarget;
 
 fn ir_words_from_bytes(buf: &[u8]) -> &[u32] {
     unsafe {
@@ -12,12 +13,12 @@ fn ir_words_from_bytes(buf: &[u8]) -> &[u32] {
 }
 
 fn main() {
-    let vertex_module = SpirvModule::new(ir_words_from_bytes(include_bytes!("vertex.spv")));
-    let parsed_vertex_module = SpirvParser::new(CompileTarget::Hlsl)
-        .parse(&vertex_module, &SpirvParserOptions::new())
+    let vertex_module = spirv::Module::new(ir_words_from_bytes(include_bytes!("vertex.spv")));
+    let parsed_vertex_module = spirv::Parser::new(CompileTarget::Hlsl)
+        .parse(&vertex_module, &spirv::ParserOptions::new())
         .unwrap();
-    let hlsl = HlslCompiler::new()
-        .compile(&parsed_vertex_module, &HlslCompilerOptions::new())
+    let hlsl = hlsl::Compiler::new()
+        .compile(&parsed_vertex_module, &hlsl::CompilerOptions::new())
         .unwrap();
     println!("{}", hlsl);
 }

--- a/examples/src/hlsl/main.rs
+++ b/examples/src/hlsl/main.rs
@@ -1,5 +1,6 @@
 extern crate spirv_cross;
-use spirv_cross::compile::{HlslCompileOptions, HlslCompiler, SpirvParseOptions, SpirvModule};
+use spirv_cross::{CompileTarget, HlslCompiler, HlslCompilerOptions, SpirvModule, SpirvParser,
+                  SpirvParserOptions};
 
 fn ir_words_from_bytes(buf: &[u8]) -> &[u32] {
     unsafe {
@@ -12,12 +13,11 @@ fn ir_words_from_bytes(buf: &[u8]) -> &[u32] {
 
 fn main() {
     let vertex_module = SpirvModule::new(ir_words_from_bytes(include_bytes!("vertex.spv")));
-    let hlsl_compiler = HlslCompiler::new();
-    let parsed_vertex_module = hlsl_compiler
-        .parse(&vertex_module, &SpirvParseOptions::new())
+    let parsed_vertex_module = SpirvParser::new(CompileTarget::Hlsl)
+        .parse(&vertex_module, &SpirvParserOptions::new())
         .unwrap();
-    let hlsl = hlsl_compiler
-        .compile(&parsed_vertex_module, &HlslCompileOptions::new())
+    let hlsl = HlslCompiler::new()
+        .compile(&parsed_vertex_module, &HlslCompilerOptions::new())
         .unwrap();
     println!("{}", hlsl);
 }

--- a/examples/src/hlsl/main.rs
+++ b/examples/src/hlsl/main.rs
@@ -14,11 +14,21 @@ fn ir_words_from_bytes(buf: &[u8]) -> &[u32] {
 
 fn main() {
     let vertex_module = spirv::Module::new(ir_words_from_bytes(include_bytes!("vertex.spv")));
+
+    // Parse a SPIR-V module
     let parsed_vertex_module = spirv::Parser::new(CompileTarget::Hlsl)
         .parse(&vertex_module, &spirv::ParserOptions::new())
         .unwrap();
+
+    // List all entry points
+    for entry_point in parsed_vertex_module.get_entry_points().unwrap() {
+        println!("{:?}", entry_point);
+    }
+
+    // Compile to HLSL
     let hlsl = hlsl::Compiler::new()
         .compile(&parsed_vertex_module, &hlsl::CompilerOptions::new())
         .unwrap();
+
     println!("{}", hlsl);
 }

--- a/spirv_cross/Cargo.toml
+++ b/spirv_cross/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirv_cross"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Joshua Groves <josh@joshgroves.com>"]
 description = "Safe wrapper around SPIRV-Cross"
 license = "Apache-2.0"

--- a/spirv_cross/src/bindings.rs
+++ b/spirv_cross/src/bindings.rs
@@ -1383,10 +1383,63 @@ pub mod root {
             fn clone(&self) -> Self { *self }
         }
     }
+    pub type ScInternalCompilerBase = ::std::os::raw::c_void;
     pub type ScInternalCompilerHlsl = ::std::os::raw::c_void;
     #[repr(i32)]
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
     pub enum ScInternalResult { Success = 0, Unhandled = 1, }
+    #[repr(C)]
+    #[derive(Debug, Copy)]
+    pub struct ScEntryPoint {
+        pub name: *mut ::std::os::raw::c_char,
+        pub execution_model: root::spv::ExecutionModel,
+        pub workgroup_size_x: u32,
+        pub workgroup_size_y: u32,
+        pub workgroup_size_z: u32,
+    }
+    #[test]
+    fn bindgen_test_layout_ScEntryPoint() {
+        assert_eq!(::std::mem::size_of::<ScEntryPoint>() , 24usize , concat !
+                   ( "Size of: " , stringify ! ( ScEntryPoint ) ));
+        assert_eq! (::std::mem::align_of::<ScEntryPoint>() , 8usize , concat !
+                    ( "Alignment of " , stringify ! ( ScEntryPoint ) ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const ScEntryPoint ) ) . name as * const _
+                    as usize } , 0usize , concat ! (
+                    "Alignment of field: " , stringify ! ( ScEntryPoint ) ,
+                    "::" , stringify ! ( name ) ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const ScEntryPoint ) ) . execution_model as
+                    * const _ as usize } , 8usize , concat ! (
+                    "Alignment of field: " , stringify ! ( ScEntryPoint ) ,
+                    "::" , stringify ! ( execution_model ) ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const ScEntryPoint ) ) . workgroup_size_x
+                    as * const _ as usize } , 12usize , concat ! (
+                    "Alignment of field: " , stringify ! ( ScEntryPoint ) ,
+                    "::" , stringify ! ( workgroup_size_x ) ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const ScEntryPoint ) ) . workgroup_size_y
+                    as * const _ as usize } , 16usize , concat ! (
+                    "Alignment of field: " , stringify ! ( ScEntryPoint ) ,
+                    "::" , stringify ! ( workgroup_size_y ) ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const ScEntryPoint ) ) . workgroup_size_z
+                    as * const _ as usize } , 20usize , concat ! (
+                    "Alignment of field: " , stringify ! ( ScEntryPoint ) ,
+                    "::" , stringify ! ( workgroup_size_z ) ));
+    }
+    impl Clone for ScEntryPoint {
+        fn clone(&self) -> Self { *self }
+    }
+    extern "C" {
+        pub fn sc_internal_compiler_base_get_entry_points(compiler:
+                                                              *const root::ScInternalCompilerBase,
+                                                          entry_points:
+                                                              *mut *mut root::ScEntryPoint,
+                                                          size: *mut usize)
+         -> root::ScInternalResult;
+    }
     extern "C" {
         pub fn sc_internal_compiler_hlsl_new(compiler:
                                                  *mut *mut root::ScInternalCompilerHlsl,
@@ -1395,18 +1448,18 @@ pub mod root {
     }
     extern "C" {
         pub fn sc_internal_compiler_hlsl_delete(compiler:
-                                                    *const root::ScInternalCompilerHlsl)
+                                                    *mut root::ScInternalCompilerHlsl)
          -> root::ScInternalResult;
     }
     extern "C" {
         pub fn sc_internal_compiler_hlsl_compile(compiler:
                                                      *const root::ScInternalCompilerHlsl,
-                                                 compiled:
+                                                 hlsl:
                                                      *mut *mut ::std::os::raw::c_char)
          -> root::ScInternalResult;
     }
     extern "C" {
-        pub fn sc_internal_deallocate_string(str: *mut ::std::os::raw::c_char)
+        pub fn sc_internal_free_pointer(pointer: *mut ::std::os::raw::c_void)
          -> root::ScInternalResult;
     }
 }

--- a/spirv_cross/src/hlsl.rs
+++ b/spirv_cross/src/hlsl.rs
@@ -46,7 +46,7 @@ impl Compiler {
                 Err(_) => return Err(ErrorCode::Unhandled),
                 Ok(v) => v,
             };
-            check!(sc_internal_deallocate_string(hlsl_ptr));
+            check!(sc_internal_free_pointer(hlsl_ptr as *mut c_void));
             Ok(hlsl)
         }
     }

--- a/spirv_cross/src/hlsl.rs
+++ b/spirv_cross/src/hlsl.rs
@@ -1,0 +1,53 @@
+use super::{CompileTarget, ErrorCode};
+use spirv;
+use bindings::root::*;
+use std::ptr;
+use std::ffi::CStr;
+use std::os::raw::c_void;
+
+#[derive(Debug, Clone)]
+pub struct CompilerOptions;
+
+impl CompilerOptions {
+    pub fn new() -> CompilerOptions {
+        CompilerOptions
+    }
+}
+
+pub(super) fn internal_delete_compiler_hlsl(internal_compiler: *mut c_void) {
+    unsafe {
+        if ScInternalResult::Success != sc_internal_compiler_hlsl_delete(internal_compiler) {
+            panic!("Cannot delete compiler");
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Compiler;
+
+impl Compiler {
+    pub fn new() -> Compiler {
+        Compiler
+    }
+
+    pub fn compile(
+        &self,
+        module: &spirv::ParsedModule,
+        _options: &CompilerOptions,
+    ) -> Result<String, ErrorCode> {
+        if module.compile_target != CompileTarget::Hlsl {
+            return Err(ErrorCode::Unhandled);
+        }
+        let compiler = module.internal_compiler;
+        unsafe {
+            let mut hlsl_ptr = ptr::null_mut();
+            check!(sc_internal_compiler_hlsl_compile(compiler, &mut hlsl_ptr));
+            let hlsl = match CStr::from_ptr(hlsl_ptr).to_owned().into_string() {
+                Err(_) => return Err(ErrorCode::Unhandled),
+                Ok(v) => v,
+            };
+            check!(sc_internal_deallocate_string(hlsl_ptr));
+            Ok(hlsl)
+        }
+    }
+}

--- a/spirv_cross/src/lib.rs
+++ b/spirv_cross/src/lib.rs
@@ -1,3 +1,8 @@
+use ScInternal::root::*;
+use std::ptr;
+use std::ffi::CStr;
+use std::os::raw::c_void;
+
 mod ScInternal {
     #![allow(dead_code)]
     #![allow(non_upper_case_globals)]
@@ -17,86 +22,70 @@ macro_rules! check {
     }}
 }
 
-pub mod compile {
-    use ScInternal::root::*;
-    use std::ptr;
-    use std::ffi::CStr;
-    use std::os::raw::c_void;
 
-    #[derive(Debug)]
-    pub enum ErrorCode {
-        Unhandled = 1,
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+pub enum ErrorCode {
+    Unhandled = 1,
+}
+
+#[derive(Debug, Clone)]
+pub struct SpirvModule<'a> {
+    ir: &'a [u32],
+}
+
+impl<'a> SpirvModule<'a> {
+    pub fn new(ir: &[u32]) -> SpirvModule {
+        SpirvModule { ir }
+    }
+}
+
+pub struct ParsedSpirvModule {
+    // TODO: Temporarily keep reference to compiler to share between parse/compile steps
+    internal_compiler: *mut c_void,
+    internal_delete_compiler: fn(*mut c_void),
+    compile_target: CompileTarget,
+}
+
+impl Drop for ParsedSpirvModule {
+    fn drop(&mut self) {
+        (self.internal_delete_compiler)(self.internal_compiler);
+    }
+}
+
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+pub enum CompileTarget {
+    Hlsl,
+}
+
+#[derive(Debug, Clone)]
+pub struct SpirvParserOptions;
+
+impl SpirvParserOptions {
+    pub fn new() -> SpirvParserOptions {
+        SpirvParserOptions
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SpirvParser {
+    compile_target: CompileTarget,
+}
+
+impl SpirvParser {
+    // TODO: Remove `compile_target`, see https://github.com/KhronosGroup/SPIRV-Cross/issues/287
+    pub fn new(compile_target: CompileTarget) -> SpirvParser {
+        SpirvParser { compile_target }
     }
 
-    #[derive(Debug, Clone)]
-    pub struct SpirvModule<'a> {
-        ir: &'a [u32],
-    }
-
-    impl<'a> SpirvModule<'a> {
-        pub fn new(ir: &[u32]) -> SpirvModule {
-            SpirvModule { ir }
-        }
-    }
-
-    pub struct ParsedSpirvModule {
-        // TODO: Currently parsing and compilation must occur with the same compiler instance
-        // (i.e. as opposed to splitting the parser/compiler which would be the ideal)
-        // So temporarily we create the compiler instance during parse
-        // and reuse it during compilation
-        // see https://github.com/KhronosGroup/SPIRV-Cross/issues/287
-        internal_compiler: *mut c_void,
-        internal_delete_compiler: fn(*mut c_void),
-    }
-
-    impl Drop for ParsedSpirvModule {
-        fn drop(&mut self) {
-            (self.internal_delete_compiler)(self.internal_compiler);
-        }
-    }
-
-    #[derive(Debug, Clone)]
-    pub struct SpirvParseOptions;
-
-    impl SpirvParseOptions {
-        pub fn new() -> SpirvParseOptions {
-            SpirvParseOptions
-        }
-    }
-
-    #[derive(Debug, Clone)]
-    pub struct HlslCompileOptions;
-
-    impl HlslCompileOptions {
-        pub fn new() -> HlslCompileOptions {
-            HlslCompileOptions
-        }
-    }
-
-    fn internal_delete_compiler_hlsl(internal_compiler: *mut c_void) {
-        unsafe {
-            if ScInternalResult::Success != sc_internal_compiler_hlsl_delete(internal_compiler) {
-                panic!("Cannot delete compiler");
-            }
-        }
-    }
-
-    #[derive(Debug, Clone)]
-    pub struct HlslCompiler;
-
-    impl HlslCompiler {
-        pub fn new() -> HlslCompiler {
-            HlslCompiler
-        }
-
-        pub fn parse(
-            &self,
-            module: &SpirvModule,
-            _options: &SpirvParseOptions,
-        ) -> Result<ParsedSpirvModule, ErrorCode> {
-            let ptr = module.ir.as_ptr() as *const u32;
-            let mut compiler = ptr::null_mut();
-            unsafe {
+    pub fn parse(
+        &self,
+        module: &SpirvModule,
+        _options: &SpirvParserOptions,
+    ) -> Result<ParsedSpirvModule, ErrorCode> {
+        let ptr = module.ir.as_ptr() as *const u32;
+        let mut compiler = ptr::null_mut();
+        match self.compile_target {
+            CompileTarget::Hlsl => unsafe {
                 check!(sc_internal_compiler_hlsl_new(
                     &mut compiler,
                     ptr,
@@ -106,26 +95,56 @@ pub mod compile {
                 Ok(ParsedSpirvModule {
                     internal_compiler: compiler,
                     internal_delete_compiler: internal_delete_compiler_hlsl,
+                    compile_target: self.compile_target.clone(),
                 })
-            }
+            },
         }
+    }
+}
 
-        pub fn compile(
-            &self,
-            module: &ParsedSpirvModule,
-            _options: &HlslCompileOptions,
-        ) -> Result<String, ErrorCode> {
-            let compiler = module.internal_compiler;
-            unsafe {
-                let mut hlsl_ptr = ptr::null_mut();
-                check!(sc_internal_compiler_hlsl_compile(compiler, &mut hlsl_ptr));
-                let hlsl = match CStr::from_ptr(hlsl_ptr).to_owned().into_string() {
-                    Err(_) => return Err(ErrorCode::Unhandled),
-                    Ok(v) => v,
-                };
-                check!(sc_internal_deallocate_string(hlsl_ptr));
-                Ok(hlsl)
-            }
+#[derive(Debug, Clone)]
+pub struct HlslCompilerOptions;
+
+impl HlslCompilerOptions {
+    pub fn new() -> HlslCompilerOptions {
+        HlslCompilerOptions
+    }
+}
+
+fn internal_delete_compiler_hlsl(internal_compiler: *mut c_void) {
+    unsafe {
+        if ScInternalResult::Success != sc_internal_compiler_hlsl_delete(internal_compiler) {
+            panic!("Cannot delete compiler");
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct HlslCompiler;
+
+impl HlslCompiler {
+    pub fn new() -> HlslCompiler {
+        HlslCompiler
+    }
+
+    pub fn compile(
+        &self,
+        module: &ParsedSpirvModule,
+        _options: &HlslCompilerOptions,
+    ) -> Result<String, ErrorCode> {
+        if module.compile_target != CompileTarget::Hlsl {
+            return Err(ErrorCode::Unhandled);
+        }
+        let compiler = module.internal_compiler;
+        unsafe {
+            let mut hlsl_ptr = ptr::null_mut();
+            check!(sc_internal_compiler_hlsl_compile(compiler, &mut hlsl_ptr));
+            let hlsl = match CStr::from_ptr(hlsl_ptr).to_owned().into_string() {
+                Err(_) => return Err(ErrorCode::Unhandled),
+                Ok(v) => v,
+            };
+            check!(sc_internal_deallocate_string(hlsl_ptr));
+            Ok(hlsl)
         }
     }
 }

--- a/spirv_cross/src/lib.rs
+++ b/spirv_cross/src/lib.rs
@@ -1,16 +1,3 @@
-use ScInternal::root::*;
-use std::ptr;
-use std::ffi::CStr;
-use std::os::raw::c_void;
-
-mod ScInternal {
-    #![allow(dead_code)]
-    #![allow(non_upper_case_globals)]
-    #![allow(non_camel_case_types)]
-    #![allow(non_snake_case)]
-    include!(concat!("bindings.rs"));
-}
-
 macro_rules! check {
     ($check:expr) => {{
         let result = $check;
@@ -22,129 +9,23 @@ macro_rules! check {
     }}
 }
 
+pub mod spirv;
+pub mod hlsl;
+
+mod bindings {
+    #![allow(dead_code)]
+    #![allow(non_upper_case_globals)]
+    #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
+    include!(concat!("bindings.rs"));
+}
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub enum ErrorCode {
     Unhandled = 1,
 }
 
-#[derive(Debug, Clone)]
-pub struct SpirvModule<'a> {
-    ir: &'a [u32],
-}
-
-impl<'a> SpirvModule<'a> {
-    pub fn new(ir: &[u32]) -> SpirvModule {
-        SpirvModule { ir }
-    }
-}
-
-pub struct ParsedSpirvModule {
-    // TODO: Temporarily keep reference to compiler to share between parse/compile steps
-    internal_compiler: *mut c_void,
-    internal_delete_compiler: fn(*mut c_void),
-    compile_target: CompileTarget,
-}
-
-impl Drop for ParsedSpirvModule {
-    fn drop(&mut self) {
-        (self.internal_delete_compiler)(self.internal_compiler);
-    }
-}
-
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub enum CompileTarget {
     Hlsl,
-}
-
-#[derive(Debug, Clone)]
-pub struct SpirvParserOptions;
-
-impl SpirvParserOptions {
-    pub fn new() -> SpirvParserOptions {
-        SpirvParserOptions
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct SpirvParser {
-    compile_target: CompileTarget,
-}
-
-impl SpirvParser {
-    // TODO: Remove `compile_target`, see https://github.com/KhronosGroup/SPIRV-Cross/issues/287
-    pub fn new(compile_target: CompileTarget) -> SpirvParser {
-        SpirvParser { compile_target }
-    }
-
-    pub fn parse(
-        &self,
-        module: &SpirvModule,
-        _options: &SpirvParserOptions,
-    ) -> Result<ParsedSpirvModule, ErrorCode> {
-        let ptr = module.ir.as_ptr() as *const u32;
-        let mut compiler = ptr::null_mut();
-        match self.compile_target {
-            CompileTarget::Hlsl => unsafe {
-                check!(sc_internal_compiler_hlsl_new(
-                    &mut compiler,
-                    ptr,
-                    module.ir.len() as usize,
-                ));
-
-                Ok(ParsedSpirvModule {
-                    internal_compiler: compiler,
-                    internal_delete_compiler: internal_delete_compiler_hlsl,
-                    compile_target: self.compile_target.clone(),
-                })
-            },
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct HlslCompilerOptions;
-
-impl HlslCompilerOptions {
-    pub fn new() -> HlslCompilerOptions {
-        HlslCompilerOptions
-    }
-}
-
-fn internal_delete_compiler_hlsl(internal_compiler: *mut c_void) {
-    unsafe {
-        if ScInternalResult::Success != sc_internal_compiler_hlsl_delete(internal_compiler) {
-            panic!("Cannot delete compiler");
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct HlslCompiler;
-
-impl HlslCompiler {
-    pub fn new() -> HlslCompiler {
-        HlslCompiler
-    }
-
-    pub fn compile(
-        &self,
-        module: &ParsedSpirvModule,
-        _options: &HlslCompilerOptions,
-    ) -> Result<String, ErrorCode> {
-        if module.compile_target != CompileTarget::Hlsl {
-            return Err(ErrorCode::Unhandled);
-        }
-        let compiler = module.internal_compiler;
-        unsafe {
-            let mut hlsl_ptr = ptr::null_mut();
-            check!(sc_internal_compiler_hlsl_compile(compiler, &mut hlsl_ptr));
-            let hlsl = match CStr::from_ptr(hlsl_ptr).to_owned().into_string() {
-                Err(_) => return Err(ErrorCode::Unhandled),
-                Ok(v) => v,
-            };
-            check!(sc_internal_deallocate_string(hlsl_ptr));
-            Ok(hlsl)
-        }
-    }
 }

--- a/spirv_cross/src/spirv.rs
+++ b/spirv_cross/src/spirv.rs
@@ -1,0 +1,74 @@
+use super::{CompileTarget, ErrorCode};
+use hlsl;
+use bindings::root::*;
+use std::ptr;
+use std::os::raw::c_void;
+
+#[derive(Debug, Clone)]
+pub struct Module<'a> {
+    ir: &'a [u32],
+}
+
+impl<'a> Module<'a> {
+    pub fn new(ir: &[u32]) -> Module {
+        Module { ir }
+    }
+}
+
+pub struct ParsedModule {
+    // TODO: Temporarily keep reference to compiler to share between parse/compile steps
+    pub(crate) internal_compiler: *mut c_void,
+    pub(crate) internal_delete_compiler: fn(*mut c_void),
+    pub(crate) compile_target: CompileTarget,
+}
+
+impl Drop for ParsedModule {
+    fn drop(&mut self) {
+        (self.internal_delete_compiler)(self.internal_compiler);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ParserOptions;
+
+impl ParserOptions {
+    pub fn new() -> ParserOptions {
+        ParserOptions
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Parser {
+    compile_target: CompileTarget,
+}
+
+impl Parser {
+    // TODO: Remove `compile_target`, see https://github.com/KhronosGroup/SPIRV-Cross/issues/287
+    pub fn new(compile_target: CompileTarget) -> Parser {
+        Parser { compile_target }
+    }
+
+    pub fn parse(
+        &self,
+        module: &Module,
+        _options: &ParserOptions,
+    ) -> Result<ParsedModule, ErrorCode> {
+        let ptr = module.ir.as_ptr() as *const u32;
+        let mut compiler = ptr::null_mut();
+        match self.compile_target {
+            CompileTarget::Hlsl => unsafe {
+                check!(sc_internal_compiler_hlsl_new(
+                    &mut compiler,
+                    ptr,
+                    module.ir.len() as usize,
+                ));
+
+                Ok(ParsedModule {
+                    internal_compiler: compiler,
+                    internal_delete_compiler: hlsl::internal_delete_compiler_hlsl,
+                    compile_target: self.compile_target.clone(),
+                })
+            },
+        }
+    }
+}

--- a/spirv_cross/src/wrapper.cpp
+++ b/spirv_cross/src/wrapper.cpp
@@ -20,6 +20,26 @@
     return ScInternalResult::Unhandled;
 
 extern "C" {
+ScInternalResult sc_internal_compiler_base_get_entry_points(const ScInternalCompilerBase *compiler, ScEntryPoint **entry_points, size_t *size)
+{
+    INTERNAL_RESULT(
+        auto const &entry_point_names = ((spirv_cross::Compiler *)compiler)->get_entry_points();
+        auto const &len = entry_point_names.size();
+        ScEntryPoint *eps = (ScEntryPoint *)malloc(len * sizeof(ScEntryPoint));
+        size_t i = 0;
+        for (auto const &name
+             : entry_point_names) {
+            auto const &entry_point = ((spirv_cross::Compiler *)compiler)->get_entry_point(name);
+            eps[i].name = strdup(name.c_str());
+            eps[i].execution_model = entry_point.model;
+            eps[i].workgroup_size_x = entry_point.workgroup_size.x;
+            eps[i].workgroup_size_y = entry_point.workgroup_size.y;
+            eps[i].workgroup_size_z = entry_point.workgroup_size.z;
+            i++;
+        }
+            *size = len;
+        *entry_points = eps;)
+}
 ScInternalResult sc_internal_compiler_hlsl_new(ScInternalCompilerHlsl **compiler, const uint32_t *ir, size_t size)
 {
     INTERNAL_RESULT(
@@ -34,8 +54,8 @@ ScInternalResult sc_internal_compiler_hlsl_compile(const ScInternalCompilerHlsl 
 {
     INTERNAL_RESULT(*hlsl = strdup(((spirv_cross::CompilerHLSL *)compiler)->compile().c_str());)
 }
-ScInternalResult sc_internal_deallocate_string(char *str)
+ScInternalResult sc_internal_free_pointer(void *pointer)
 {
-    INTERNAL_RESULT(free(str);)
+    INTERNAL_RESULT(free(pointer);)
 }
 }

--- a/spirv_cross/src/wrapper.hpp
+++ b/spirv_cross/src/wrapper.hpp
@@ -1,16 +1,29 @@
 #include "vendor/SPIRV-Cross/spirv.hpp"
 #include "vendor/SPIRV-Cross/spirv_hlsl.hpp"
 
+typedef void ScInternalCompilerBase;
 typedef void ScInternalCompilerHlsl;
 
 extern "C" {
+
 enum ScInternalResult
 {
     Success = 0,
     Unhandled = 1
 };
+
+typedef struct ScEntryPoint
+{
+    char *name;
+    spv::ExecutionModel execution_model;
+    uint32_t workgroup_size_x;
+    uint32_t workgroup_size_y;
+    uint32_t workgroup_size_z;
+} ScEntryPoint;
+
+ScInternalResult sc_internal_compiler_base_get_entry_points(const ScInternalCompilerBase *compiler, ScEntryPoint **entry_points, size_t *size);
 ScInternalResult sc_internal_compiler_hlsl_new(ScInternalCompilerHlsl **compiler, const uint32_t *ir, size_t size);
 ScInternalResult sc_internal_compiler_hlsl_delete(ScInternalCompilerHlsl *compiler);
-ScInternalResult sc_internal_compiler_hlsl_compile(const ScInternalCompilerHlsl *compiler, char **compiled);
-ScInternalResult sc_internal_deallocate_string(char *str);
+ScInternalResult sc_internal_compiler_hlsl_compile(const ScInternalCompilerHlsl *compiler, char **hlsl);
+ScInternalResult sc_internal_free_pointer(void *pointer);
 }


### PR DESCRIPTION
Split `parse` from `HlslCompiler` into `SpirvParser`, remove namespace