### PR TITLE
Simplify FFI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ use spirv_cross::CompileTarget;
 
 fn generate_hlsl(module: spirv::Module) {
     // Parse a SPIR-V module
-    let parsed_module = spirv::Parser::new(CompileTarget::Hlsl)
+    let parsed_module = spirv::Parser::new()
         .parse(&module, &spirv::ParserOptions::new())
         .unwrap();
 

--- a/examples/src/hlsl/main.rs
+++ b/examples/src/hlsl/main.rs
@@ -1,7 +1,6 @@
 extern crate spirv_cross;
 use spirv_cross::spirv;
 use spirv_cross::hlsl;
-use spirv_cross::CompileTarget;
 
 fn ir_words_from_bytes(buf: &[u8]) -> &[u32] {
     unsafe {
@@ -16,12 +15,12 @@ fn main() {
     let vertex_module = spirv::Module::new(ir_words_from_bytes(include_bytes!("vertex.spv")));
 
     // Parse a SPIR-V module
-    let parsed_vertex_module = spirv::Parser::new(CompileTarget::Hlsl)
+    let parsed_vertex_module = spirv::Parser::new()
         .parse(&vertex_module, &spirv::ParserOptions::new())
         .unwrap();
 
     // List all entry points
-    for entry_point in parsed_vertex_module.get_entry_points().unwrap() {
+    for entry_point in &parsed_vertex_module.entry_points {
         println!("{:?}", entry_point);
     }
 

--- a/spirv_cross/src/bindings.rs
+++ b/spirv_cross/src/bindings.rs
@@ -1383,8 +1383,6 @@ pub mod root {
             fn clone(&self) -> Self { *self }
         }
     }
-    pub type ScInternalCompilerBase = ::std::os::raw::c_void;
-    pub type ScInternalCompilerHlsl = ::std::os::raw::c_void;
     #[repr(i32)]
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
     pub enum ScInternalResult { Success = 0, Unhandled = 1, }
@@ -1433,27 +1431,14 @@ pub mod root {
         fn clone(&self) -> Self { *self }
     }
     extern "C" {
-        pub fn sc_internal_compiler_base_get_entry_points(compiler:
-                                                              *const root::ScInternalCompilerBase,
-                                                          entry_points:
-                                                              *mut *mut root::ScEntryPoint,
-                                                          size: *mut usize)
+        pub fn sc_internal_compiler_base_parse(ir: *const u32, size: usize,
+                                               entry_points:
+                                                   *mut *mut root::ScEntryPoint,
+                                               entry_points_size: *mut usize)
          -> root::ScInternalResult;
     }
     extern "C" {
-        pub fn sc_internal_compiler_hlsl_new(compiler:
-                                                 *mut *mut root::ScInternalCompilerHlsl,
-                                             ir: *const u32, size: usize)
-         -> root::ScInternalResult;
-    }
-    extern "C" {
-        pub fn sc_internal_compiler_hlsl_delete(compiler:
-                                                    *mut root::ScInternalCompilerHlsl)
-         -> root::ScInternalResult;
-    }
-    extern "C" {
-        pub fn sc_internal_compiler_hlsl_compile(compiler:
-                                                     *const root::ScInternalCompilerHlsl,
+        pub fn sc_internal_compiler_hlsl_compile(ir: *const u32, size: usize,
                                                  hlsl:
                                                      *mut *mut ::std::os::raw::c_char)
          -> root::ScInternalResult;

--- a/spirv_cross/src/lib.rs
+++ b/spirv_cross/src/lib.rs
@@ -24,8 +24,3 @@ mod bindings {
 pub enum ErrorCode {
     Unhandled = 1,
 }
-
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-pub enum CompileTarget {
-    Hlsl,
-}

--- a/spirv_cross/src/spirv.rs
+++ b/spirv_cross/src/spirv.rs
@@ -57,7 +57,6 @@ pub struct Parser {
 }
 
 impl Parser {
-    // TODO: Remove `compile_target`, see https://github.com/KhronosGroup/SPIRV-Cross/issues/287
     pub fn new() -> Parser {
         Parser {
             _unconstructable: (),

--- a/spirv_cross/src/spirv.rs
+++ b/spirv_cross/src/spirv.rs
@@ -1,5 +1,4 @@
-use super::{CompileTarget, ErrorCode};
-use hlsl;
+use super::ErrorCode;
 use bindings::root::*;
 use std::ptr;
 use std::os::raw::c_void;
@@ -33,56 +32,13 @@ impl<'a> Module<'a> {
 }
 
 pub struct ParsedModule {
-    // TODO: Temporarily keep reference to compiler to share between parse/compile steps
-    pub(crate) internal_compiler: *mut c_void,
-    pub(crate) internal_delete_compiler: fn(*mut c_void),
-    pub(crate) compile_target: CompileTarget,
+    pub entry_points: Vec<EntryPoint>,
+    pub(crate) ir: Vec<u32>,
 }
 
 impl ParsedModule {
-    pub fn get_entry_points(&self) -> Result<Vec<EntryPoint>, ErrorCode> {
-        unsafe {
-            let mut entry_points = ptr::null_mut();
-            let mut entry_points_length = 0 as usize;
-
-            check!(sc_internal_compiler_base_get_entry_points(
-                self.internal_compiler,
-                &mut entry_points,
-                &mut entry_points_length,
-            ));
-
-            (0..entry_points_length)
-                .map(|offset| {
-                    let ep_ptr = entry_points.offset(offset as isize);
-                    let ep = *ep_ptr;
-                    let name = match CStr::from_ptr(ep.name).to_owned().into_string() {
-                        Ok(n) => n,
-                        _ => return Err(ErrorCode::Unhandled),
-                    };
-
-                    let entry_point = EntryPoint {
-                        name,
-                        execution_model: ep.execution_model,
-                        workgroup_size: WorkgroupSize {
-                            x: ep.workgroup_size_x,
-                            y: ep.workgroup_size_y,
-                            z: ep.workgroup_size_z,
-                        },
-                    };
-
-                    check!(sc_internal_free_pointer(ep.name as *mut c_void));
-                    check!(sc_internal_free_pointer(ep_ptr as *mut c_void));
-
-                    Ok(entry_point)
-                })
-                .collect::<Result<Vec<_>, _>>()
-        }
-    }
-}
-
-impl Drop for ParsedModule {
-    fn drop(&mut self) {
-        (self.internal_delete_compiler)(self.internal_compiler);
+    fn new(ir: Vec<u32>, entry_points: Vec<EntryPoint>) -> ParsedModule {
+        ParsedModule { entry_points, ir }
     }
 }
 
@@ -97,13 +53,15 @@ impl ParserOptions {
 
 #[derive(Debug, Clone)]
 pub struct Parser {
-    compile_target: CompileTarget,
+    _unconstructable: (),
 }
 
 impl Parser {
     // TODO: Remove `compile_target`, see https://github.com/KhronosGroup/SPIRV-Cross/issues/287
-    pub fn new(compile_target: CompileTarget) -> Parser {
-        Parser { compile_target }
+    pub fn new() -> Parser {
+        Parser {
+            _unconstructable: (),
+        }
     }
 
     pub fn parse(
@@ -111,22 +69,58 @@ impl Parser {
         module: &Module,
         _options: &ParserOptions,
     ) -> Result<ParsedModule, ErrorCode> {
-        let ptr = module.ir.as_ptr() as *const u32;
-        let mut compiler = ptr::null_mut();
-        match self.compile_target {
-            CompileTarget::Hlsl => unsafe {
-                check!(sc_internal_compiler_hlsl_new(
-                    &mut compiler,
-                    ptr,
-                    module.ir.len() as usize,
-                ));
+        unsafe {
+            let mut entry_points_raw = ptr::null_mut();
+            let mut entry_points_raw_length = 0 as usize;
 
-                Ok(ParsedModule {
-                    internal_compiler: compiler,
-                    internal_delete_compiler: hlsl::internal_delete_compiler_hlsl,
-                    compile_target: self.compile_target.clone(),
+            let mut ir = vec![0; module.ir.len()];
+            ir.copy_from_slice(module.ir);
+
+            check!(sc_internal_compiler_base_parse(
+                ir.as_ptr() as *const u32,
+                ir.len() as usize,
+                &mut entry_points_raw,
+                &mut entry_points_raw_length,
+            ));
+
+            let entry_points = (0..entry_points_raw_length)
+                .map(|offset| {
+                    let entry_point_raw_ptr = entry_points_raw.offset(offset as isize);
+                    let entry_point_raw = *entry_point_raw_ptr;
+                    let name = match CStr::from_ptr(entry_point_raw.name)
+                        .to_owned()
+                        .into_string()
+                    {
+                        Ok(n) => n,
+                        _ => return Err(ErrorCode::Unhandled),
+                    };
+
+                    let entry_point = EntryPoint {
+                        name,
+                        execution_model: entry_point_raw.execution_model,
+                        workgroup_size: WorkgroupSize {
+                            x: entry_point_raw.workgroup_size_x,
+                            y: entry_point_raw.workgroup_size_y,
+                            z: entry_point_raw.workgroup_size_z,
+                        },
+                    };
+
+                    check!(sc_internal_free_pointer(
+                        entry_point_raw.name as *mut c_void,
+                    ));
+                    check!(sc_internal_free_pointer(entry_point_raw_ptr as *mut c_void));
+
+                    Ok(entry_point)
                 })
-            },
+                .collect::<Result<Vec<_>, _>>();
+
+            Ok(ParsedModule::new(
+                ir,
+                match entry_points {
+                    Ok(e) => e,
+                    Err(e) => return Err(e),
+                },
+            ))
         }
     }
 }

--- a/spirv_cross/src/wrapper.cpp
+++ b/spirv_cross/src/wrapper.cpp
@@ -20,9 +20,11 @@
     return ScInternalResult::Unhandled;
 
 extern "C" {
-ScInternalResult sc_internal_compiler_base_get_entry_points(const ScInternalCompilerBase *compiler, ScEntryPoint **entry_points, size_t *size)
+ScInternalResult sc_internal_compiler_base_parse(const uint32_t *ir, size_t size, ScEntryPoint **entry_points, size_t *entry_points_size)
 {
     INTERNAL_RESULT(
+        auto const &compiler = new spirv_cross::Compiler(ir, size);
+
         auto const &entry_point_names = ((spirv_cross::Compiler *)compiler)->get_entry_points();
         auto const &len = entry_point_names.size();
         ScEntryPoint *eps = (ScEntryPoint *)malloc(len * sizeof(ScEntryPoint));
@@ -37,23 +39,20 @@ ScInternalResult sc_internal_compiler_base_get_entry_points(const ScInternalComp
             eps[i].workgroup_size_z = entry_point.workgroup_size.z;
             i++;
         }
-            *size = len;
-        *entry_points = eps;)
+            *entry_points = eps;
+        *entry_points_size = len;
+
+        delete (spirv_cross::Compiler *)compiler;)
 }
-ScInternalResult sc_internal_compiler_hlsl_new(ScInternalCompilerHlsl **compiler, const uint32_t *ir, size_t size)
+
+ScInternalResult sc_internal_compiler_hlsl_compile(const uint32_t *ir, size_t size, char **hlsl)
 {
     INTERNAL_RESULT(
-            *compiler = new spirv_cross::CompilerHLSL(ir, size);)
-}
-ScInternalResult sc_internal_compiler_hlsl_delete(ScInternalCompilerHlsl *compiler)
-{
-    INTERNAL_RESULT(
+        auto const &compiler = new spirv_cross::CompilerHLSL(ir, size);
+        *hlsl = strdup(((spirv_cross::CompilerHLSL *)compiler)->compile().c_str());
         delete (spirv_cross::CompilerHLSL *)compiler;)
 }
-ScInternalResult sc_internal_compiler_hlsl_compile(const ScInternalCompilerHlsl *compiler, char **hlsl)
-{
-    INTERNAL_RESULT(*hlsl = strdup(((spirv_cross::CompilerHLSL *)compiler)->compile().c_str());)
-}
+
 ScInternalResult sc_internal_free_pointer(void *pointer)
 {
     INTERNAL_RESULT(free(pointer);)

--- a/spirv_cross/src/wrapper.hpp
+++ b/spirv_cross/src/wrapper.hpp
@@ -21,9 +21,9 @@ typedef struct ScEntryPoint
     uint32_t workgroup_size_z;
 } ScEntryPoint;
 
-ScInternalResult sc_internal_compiler_base_get_entry_points(const ScInternalCompilerBase *compiler, ScEntryPoint **entry_points, size_t *size);
-ScInternalResult sc_internal_compiler_hlsl_new(ScInternalCompilerHlsl **compiler, const uint32_t *ir, size_t size);
-ScInternalResult sc_internal_compiler_hlsl_delete(ScInternalCompilerHlsl *compiler);
-ScInternalResult sc_internal_compiler_hlsl_compile(const ScInternalCompilerHlsl *compiler, char **hlsl);
+ScInternalResult sc_internal_compiler_base_parse(const uint32_t *ir, size_t size, ScEntryPoint **entry_points, size_t *entry_points_size);
+
+ScInternalResult sc_internal_compiler_hlsl_compile(const uint32_t *ir, size_t size, char **hlsl);
+
 ScInternalResult sc_internal_free_pointer(void *pointer);
 }


### PR DESCRIPTION
- This simplifies the FFI C externs by avoiding crossing FFI boundary to call constructors/destructors (instead parse and compile methods are provided).
- Parse now returns the entry points also, instead of keeping the compiler alive for deferred queries. If this turns out to be too expensive then these can be switched back to functions, however most of this information should be relatively cheap and will usually be needed by the caller anyway.
- One (possibly large) downside to this approach is that SPIR-V modules are [parsed twice, although this will hopefully improve in the future](https://github.com/KhronosGroup/SPIRV-Cross/issues/287). However the parsing should be cheap so it may not be an issue at the moment.