### PR TITLE
[RFC] Refactor API and add decoration reflection

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,26 +15,21 @@
 
 ```rust
 extern crate spirv_cross;
-use spirv_cross::{spirv, hlsl, msl};
+use spirv_cross::{spirv, hlsl, msl, ErrorCode};
 
-fn example(module: spirv::Module) {
-    // Parse a SPIR-V module
-    let parsed_module = spirv::Parser::new()
-        .parse(&module, &spirv::ParserOptions::default())
-        .unwrap();
-
+fn example(module: spirv::Module) -> Result<(), ErrorCode> {
     // Compile to HLSL
-    let hlsl = hlsl::Compiler::new()
-        .compile(&parsed_module, &hlsl::CompilerOptions::default())
-        .unwrap();
+    let hlsl = hlsl::Compiler::from_module(&module)?
+        .compile(&hlsl::CompilerOptions::default())?;
 
     println!("{}", hlsl);
 
     // Compile to MSL
-    let msl = msl::Compiler::new()
-        .compile(&parsed_module, &msl::CompilerOptions::default())
-        .unwrap();
+    let msl = msl::Compiler::from_module(&module)?
+        .compile(&msl::CompilerOptions::default())?;
 
     println!("{}", msl);
+
+    Ok(())
 }
 ```

--- a/README.md
+++ b/README.md
@@ -19,13 +19,15 @@ use spirv_cross::{spirv, hlsl, msl, ErrorCode};
 
 fn example(module: spirv::Module) -> Result<(), ErrorCode> {
     // Compile to HLSL
-    let hlsl = hlsl::Compiler::from_module(&module)?
+    let ast = spirv::Ast::parse(&module, spirv::Target::Hlsl)?;
+    let hlsl = hlsl::Compiler::from_ast(&ast)
         .compile(&hlsl::CompilerOptions::default())?;
 
     println!("{}", hlsl);
 
     // Compile to MSL
-    let msl = msl::Compiler::from_module(&module)?
+    let ast = spirv::Ast::parse(&module, spirv::Target::Msl)?;
+    let msl = msl::Compiler::from_ast(&ast)
         .compile(&msl::CompilerOptions::default())?;
 
     println!("{}", msl);

--- a/examples/src/hlsl/main.rs
+++ b/examples/src/hlsl/main.rs
@@ -14,18 +14,16 @@ fn main() {
     let vertex_module = spirv::Module::new(ir_words_from_bytes(include_bytes!("vertex.spv")));
 
     // Parse a SPIR-V module
-    let parsed_vertex_module = spirv::Parser::new()
-        .parse(&vertex_module, &spirv::ParserOptions::default())
-        .unwrap();
+    let compiler = hlsl::Compiler::from_module(&vertex_module).unwrap();
 
     // List all entry points
-    for entry_point in &parsed_vertex_module.entry_points {
+    for entry_point in &compiler.get_entry_points().unwrap() {
         println!("{:?}", entry_point);
     }
 
     // Compile to HLSL
-    let hlsl = hlsl::Compiler::new()
-        .compile(&parsed_vertex_module, &hlsl::CompilerOptions::default())
+    let hlsl = compiler
+        .compile(&hlsl::CompilerOptions::default())
         .unwrap();
 
     println!("{}", hlsl);

--- a/examples/src/hlsl/main.rs
+++ b/examples/src/hlsl/main.rs
@@ -14,15 +14,15 @@ fn main() {
     let vertex_module = spirv::Module::new(ir_words_from_bytes(include_bytes!("vertex.spv")));
 
     // Parse a SPIR-V module
-    let compiler = hlsl::Compiler::from_module(&vertex_module).unwrap();
+    let ast = spirv::Ast::parse(&vertex_module, spirv::Target::Hlsl).unwrap();
 
     // List all entry points
-    for entry_point in &compiler.get_entry_points().unwrap() {
+    for entry_point in &ast.get_entry_points().unwrap() {
         println!("{:?}", entry_point);
     }
 
     // Compile to HLSL
-    let hlsl = compiler
+    let hlsl = hlsl::Compiler::from_ast(&ast)
         .compile(&hlsl::CompilerOptions::default())
         .unwrap();
 

--- a/examples/src/msl/main.rs
+++ b/examples/src/msl/main.rs
@@ -14,18 +14,16 @@ fn main() {
     let vertex_module = spirv::Module::new(ir_words_from_bytes(include_bytes!("vertex.spv")));
 
     // Parse a SPIR-V module
-    let parsed_vertex_module = spirv::Parser::new()
-        .parse(&vertex_module, &spirv::ParserOptions::default())
-        .unwrap();
+    let compiler = msl::Compiler::from_module(&vertex_module).unwrap();
 
     // List all entry points
-    for entry_point in &parsed_vertex_module.entry_points {
+    for entry_point in &compiler.get_entry_points().unwrap() {
         println!("{:?}", entry_point);
     }
 
     // Compile to MSL
-    let msl = msl::Compiler::new()
-        .compile(&parsed_vertex_module, &msl::CompilerOptions::default())
+    let msl = compiler
+        .compile(&msl::CompilerOptions::default())
         .unwrap();
 
     println!("{}", msl);

--- a/examples/src/msl/main.rs
+++ b/examples/src/msl/main.rs
@@ -14,15 +14,15 @@ fn main() {
     let vertex_module = spirv::Module::new(ir_words_from_bytes(include_bytes!("vertex.spv")));
 
     // Parse a SPIR-V module
-    let compiler = msl::Compiler::from_module(&vertex_module).unwrap();
+    let ast = spirv::Ast::parse(&vertex_module, spirv::Target::Msl).unwrap();
 
     // List all entry points
-    for entry_point in &compiler.get_entry_points().unwrap() {
+    for entry_point in &ast.get_entry_points().unwrap() {
         println!("{:?}", entry_point);
     }
 
     // Compile to MSL
-    let msl = compiler
+    let msl = msl::Compiler::from_ast(&ast)
         .compile(&msl::CompilerOptions::default())
         .unwrap();
 

--- a/spirv_cross/src/bindings.rs
+++ b/spirv_cross/src/bindings.rs
@@ -8,7 +8,7 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         pub type Id = ::std::os::raw::c_uint;
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum SourceLanguage {
             SourceLanguageUnknown = 0,
@@ -19,7 +19,7 @@ pub mod root {
             SourceLanguageHLSL = 5,
             SourceLanguageMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum ExecutionModel {
             ExecutionModelVertex = 0,
@@ -31,7 +31,7 @@ pub mod root {
             ExecutionModelKernel = 6,
             ExecutionModelMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum AddressingModel {
             AddressingModelLogical = 0,
@@ -39,7 +39,7 @@ pub mod root {
             AddressingModelPhysical64 = 2,
             AddressingModelMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum MemoryModel {
             MemoryModelSimple = 0,
@@ -47,7 +47,7 @@ pub mod root {
             MemoryModelOpenCL = 2,
             MemoryModelMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum ExecutionMode {
             ExecutionModeInvocations = 0,
@@ -83,7 +83,7 @@ pub mod root {
             ExecutionModeContractionOff = 31,
             ExecutionModeMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum StorageClass {
             StorageClassUniformConstant = 0,
@@ -101,7 +101,7 @@ pub mod root {
             StorageClassStorageBuffer = 12,
             StorageClassMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum Dim {
             Dim1D = 0,
@@ -113,7 +113,7 @@ pub mod root {
             DimSubpassData = 6,
             DimMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum SamplerAddressingMode {
             SamplerAddressingModeNone = 0,
@@ -123,14 +123,14 @@ pub mod root {
             SamplerAddressingModeRepeatMirrored = 4,
             SamplerAddressingModeMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum SamplerFilterMode {
             SamplerFilterModeNearest = 0,
             SamplerFilterModeLinear = 1,
             SamplerFilterModeMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum ImageFormat {
             ImageFormatUnknown = 0,
@@ -175,7 +175,7 @@ pub mod root {
             ImageFormatR8ui = 39,
             ImageFormatMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum ImageChannelOrder {
             ImageChannelOrderR = 0,
@@ -200,7 +200,7 @@ pub mod root {
             ImageChannelOrderABGR = 19,
             ImageChannelOrderMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum ImageChannelDataType {
             ImageChannelDataTypeSnormInt8 = 0,
@@ -222,7 +222,7 @@ pub mod root {
             ImageChannelDataTypeUnormInt101010_2 = 16,
             ImageChannelDataTypeMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum ImageOperandsShift {
             ImageOperandsBiasShift = 0,
@@ -298,8 +298,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct ImageOperandsMask(pub ::std::os::raw::c_int);
-        #[repr(i32)]
+        pub struct ImageOperandsMask(pub ::std::os::raw::c_uint);
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum FPFastMathModeShift {
             FPFastMathModeNotNaNShift = 0,
@@ -363,8 +363,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct FPFastMathModeMask(pub ::std::os::raw::c_int);
-        #[repr(i32)]
+        pub struct FPFastMathModeMask(pub ::std::os::raw::c_uint);
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum FPRoundingMode {
             FPRoundingModeRTE = 0,
@@ -373,14 +373,14 @@ pub mod root {
             FPRoundingModeRTN = 3,
             FPRoundingModeMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum LinkageType {
             LinkageTypeExport = 0,
             LinkageTypeImport = 1,
             LinkageTypeMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum AccessQualifier {
             AccessQualifierReadOnly = 0,
@@ -388,7 +388,7 @@ pub mod root {
             AccessQualifierReadWrite = 2,
             AccessQualifierMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum FunctionParameterAttribute {
             FunctionParameterAttributeZext = 0,
@@ -401,7 +401,7 @@ pub mod root {
             FunctionParameterAttributeNoReadWrite = 7,
             FunctionParameterAttributeMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum Decoration {
             DecorationRelaxedPrecision = 0,
@@ -453,7 +453,7 @@ pub mod root {
             DecorationSecondaryViewportRelativeNV = 5256,
             DecorationMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum BuiltIn {
             BuiltInPosition = 0,
@@ -514,7 +514,7 @@ pub mod root {
             BuiltInViewportMaskPerViewNV = 5262,
             BuiltInMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum SelectionControlShift {
             SelectionControlFlattenShift = 0,
@@ -567,8 +567,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct SelectionControlMask(pub ::std::os::raw::c_int);
-        #[repr(i32)]
+        pub struct SelectionControlMask(pub ::std::os::raw::c_uint);
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum LoopControlShift {
             LoopControlUnrollShift = 0,
@@ -620,8 +620,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct LoopControlMask(pub ::std::os::raw::c_int);
-        #[repr(i32)]
+        pub struct LoopControlMask(pub ::std::os::raw::c_uint);
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum FunctionControlShift {
             FunctionControlInlineShift = 0,
@@ -681,8 +681,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct FunctionControlMask(pub ::std::os::raw::c_int);
-        #[repr(i32)]
+        pub struct FunctionControlMask(pub ::std::os::raw::c_uint);
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum MemorySemanticsShift {
             MemorySemanticsAcquireShift = 1,
@@ -766,8 +766,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct MemorySemanticsMask(pub ::std::os::raw::c_int);
-        #[repr(i32)]
+        pub struct MemorySemanticsMask(pub ::std::os::raw::c_uint);
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum MemoryAccessShift {
             MemoryAccessVolatileShift = 0,
@@ -823,8 +823,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct MemoryAccessMask(pub ::std::os::raw::c_int);
-        #[repr(i32)]
+        pub struct MemoryAccessMask(pub ::std::os::raw::c_uint);
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum Scope {
             ScopeCrossDevice = 0,
@@ -834,7 +834,7 @@ pub mod root {
             ScopeInvocation = 4,
             ScopeMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum GroupOperation {
             GroupOperationReduce = 0,
@@ -890,8 +890,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct KernelEnqueueFlags(pub ::std::os::raw::c_int);
-        #[repr(i32)]
+        pub struct KernelEnqueueFlags(pub ::std::os::raw::c_uint);
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum KernelProfilingInfoShift {
             KernelProfilingInfoCmdExecTimeShift = 0,
@@ -941,14 +941,14 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct KernelProfilingInfoMask(pub ::std::os::raw::c_int);
+        pub struct KernelProfilingInfoMask(pub ::std::os::raw::c_uint);
         pub const Capability_CapabilityStorageUniformBufferBlock16:
                   root::spv::Capability =
             Capability::CapabilityStorageBuffer16BitAccess;
         pub const Capability_CapabilityUniformAndStorageBuffer16BitAccess:
                   root::spv::Capability =
             Capability::CapabilityStorageUniform16;
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum Capability {
             CapabilityMatrix = 0,
@@ -1026,7 +1026,7 @@ pub mod root {
             CapabilityPerViewAttributesNV = 5260,
             CapabilityMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum Op {
             OpNop = 0,
@@ -1335,11 +1335,11 @@ pub mod root {
     pub mod std {
         #[allow(unused_imports)]
         use self::super::super::root;
-        pub mod tr1 {
-            #[allow(unused_imports)]
-            use self::super::super::super::root;
-        }
         pub type string = [u64; 4usize];
+    }
+    pub mod __gnu_cxx {
+        #[allow(unused_imports)]
+        use self::super::super::root;
     }
     pub mod spirv_cross {
         #[allow(unused_imports)]
@@ -1383,7 +1383,10 @@ pub mod root {
             fn clone(&self) -> Self { *self }
         }
     }
-    #[repr(i32)]
+    pub type ScInternalCompilerBase = ::std::os::raw::c_void;
+    pub type ScInternalCompilerHlsl = ::std::os::raw::c_void;
+    pub type ScInternalCompilerMsl = ::std::os::raw::c_void;
+    #[repr(u32)]
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
     pub enum ScInternalResult {
         Success = 0,
@@ -1512,26 +1515,66 @@ pub mod root {
          -> root::ScInternalResult;
     }
     extern "C" {
-        pub fn sc_internal_compiler_base_parse(ir: *const u32, size: usize,
-                                               entry_points:
-                                                   *mut *mut root::ScEntryPoint,
-                                               entry_points_size: *mut usize)
+        pub fn sc_internal_compiler_hlsl_new(compiler:
+                                                 *mut *mut root::ScInternalCompilerHlsl,
+                                             ir: *const u32, size: usize)
          -> root::ScInternalResult;
     }
     extern "C" {
-        pub fn sc_internal_compiler_hlsl_compile(ir: *const u32, size: usize,
-                                                 hlsl:
-                                                     *mut *const ::std::os::raw::c_char,
-                                                 options:
-                                                     *const root::ScHlslCompilerOptions)
+        pub fn sc_internal_compiler_hlsl_set_options(compiler:
+                                                         *const root::ScInternalCompilerHlsl,
+                                                     options:
+                                                         *const root::ScHlslCompilerOptions)
          -> root::ScInternalResult;
     }
     extern "C" {
-        pub fn sc_internal_compiler_msl_compile(ir: *const u32, size: usize,
-                                                msl:
-                                                    *mut *const ::std::os::raw::c_char,
-                                                options:
-                                                    *const root::ScMslCompilerOptions)
+        pub fn sc_internal_compiler_msl_new(compiler:
+                                                *mut *mut root::ScInternalCompilerMsl,
+                                            ir: *const u32, size: usize)
+         -> root::ScInternalResult;
+    }
+    extern "C" {
+        pub fn sc_internal_compiler_msl_set_options(compiler:
+                                                        *const root::ScInternalCompilerHlsl,
+                                                    options:
+                                                        *const root::ScMslCompilerOptions)
+         -> root::ScInternalResult;
+    }
+    extern "C" {
+        pub fn sc_internal_compiler_get_decoration(compiler:
+                                                       *const root::ScInternalCompilerBase,
+                                                   result: *mut u32, id: u32,
+                                                   decoration:
+                                                       root::spv::Decoration)
+         -> root::ScInternalResult;
+    }
+    extern "C" {
+        pub fn sc_internal_compiler_set_decoration(compiler:
+                                                       *const root::ScInternalCompilerBase,
+                                                   id: u32,
+                                                   decoration:
+                                                       root::spv::Decoration,
+                                                   argument: u32)
+         -> root::ScInternalResult;
+    }
+    extern "C" {
+        pub fn sc_internal_compiler_get_entry_points(compiler:
+                                                         *const root::ScInternalCompilerBase,
+                                                     entry_points:
+                                                         *mut *mut root::ScEntryPoint,
+                                                     size: *mut usize)
+         -> root::ScInternalResult;
+    }
+    extern "C" {
+        pub fn sc_internal_compiler_compile(compiler:
+                                                *const root::ScInternalCompilerBase,
+                                            shader:
+                                                *mut *const ::std::os::raw::c_char)
+         -> root::ScInternalResult;
+    }
+    extern "C" {
+        pub fn sc_internal_compiler_delete(compiler:
+                                               *mut root::ScInternalCompilerBase)
          -> root::ScInternalResult;
     }
     extern "C" {

--- a/spirv_cross/src/compiler.rs
+++ b/spirv_cross/src/compiler.rs
@@ -1,0 +1,135 @@
+
+//! Raw compiler bindings for SPIRV-Cross.
+
+use bindings::root::*;
+use ErrorCode;
+use spirv;
+use std::ptr;
+use std::ffi::CStr;
+
+impl spirv::ExecutionModel {
+    fn from_raw(raw: spv::ExecutionModel) -> Result<spirv::ExecutionModel, ErrorCode> {
+        use spirv::ExecutionModel::*;
+        match raw {
+            spv::ExecutionModel::ExecutionModelVertex => Ok(Vertex),
+            spv::ExecutionModel::ExecutionModelTessellationControl => {
+                Ok(TessellationControl)
+            }
+            spv::ExecutionModel::ExecutionModelTessellationEvaluation => {
+                Ok(TessellationEvaluation)
+            }
+            spv::ExecutionModel::ExecutionModelGeometry => Ok(Geometry),
+            spv::ExecutionModel::ExecutionModelFragment => Ok(Fragment),
+            spv::ExecutionModel::ExecutionModelGLCompute => Ok(GlCompute),
+            spv::ExecutionModel::ExecutionModelKernel => Ok(Kernel),
+            _ => Err(ErrorCode::Unhandled),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Compiler {
+    pub sc_compiler: *mut ScInternalCompilerBase,
+}
+
+impl Compiler {
+    pub fn compile(&self) -> Result<String, ErrorCode> {
+        unsafe {
+            let mut shader_ptr = ptr::null();
+            check!(sc_internal_compiler_compile(
+                self.sc_compiler,
+                &mut shader_ptr,
+            ));
+            let shader = match CStr::from_ptr(shader_ptr).to_owned().into_string() {
+                Err(_) => return Err(ErrorCode::Unhandled),
+                Ok(v) => v,
+            };
+            check!(sc_internal_free_pointer(shader_ptr as *mut c_void));
+            Ok(shader)
+        }
+    }
+
+    pub fn get_decoration(&self, id: u32, decoration: spv::Decoration) -> Result<Option<u32>, ErrorCode> {
+        let mut result = 0;
+        unsafe {
+            check!(sc_internal_compiler_get_decoration(
+                self.sc_compiler,
+                &mut result,
+                id,
+                decoration,
+            ));
+        }
+
+        Ok(match result {
+            0 => None,
+            _ => Some(result),
+        })
+    }
+
+    pub fn set_decoration(&self, id: u32, decoration: spv::Decoration, argument: u32) -> Result<(), ErrorCode> {
+        unsafe {
+            check!(sc_internal_compiler_set_decoration(
+                self.sc_compiler,
+                id,
+                decoration,
+                argument,
+            ));
+        }
+
+        Ok(())
+    }
+
+    pub fn get_entry_points(&self) -> Result<Vec<spirv::EntryPoint>, ErrorCode> {
+        let mut entry_points_raw = ptr::null_mut();
+        let mut entry_points_raw_length = 0 as usize;
+
+        unsafe {
+            check!(sc_internal_compiler_get_entry_points(
+                self.sc_compiler,
+                &mut entry_points_raw,
+                &mut entry_points_raw_length,
+            ));
+
+            let entry_points = (0..entry_points_raw_length)
+                .map(|offset| {
+                    let entry_point_raw_ptr = entry_points_raw.offset(offset as isize);
+                    let entry_point_raw = *entry_point_raw_ptr;
+                    let name = match CStr::from_ptr(entry_point_raw.name)
+                        .to_owned()
+                        .into_string()
+                    {
+                        Ok(n) => n,
+                        _ => return Err(ErrorCode::Unhandled),
+                    };
+
+                    let entry_point = spirv::EntryPoint {
+                        name,
+                        execution_model: try!(
+                            spirv::ExecutionModel::from_raw(entry_point_raw.execution_model)
+                        ),
+                        workgroup_size: spirv::WorkgroupSize {
+                            x: entry_point_raw.workgroup_size_x,
+                            y: entry_point_raw.workgroup_size_y,
+                            z: entry_point_raw.workgroup_size_z,
+                        },
+                    };
+
+                    check!(sc_internal_free_pointer(
+                        entry_point_raw.name as *mut c_void,
+                    ));
+                    check!(sc_internal_free_pointer(entry_point_raw_ptr as *mut c_void));
+
+                    Ok(entry_point)
+                })
+                .collect::<Result<Vec<_>, _>>();
+
+            Ok(try!(entry_points))
+        }
+    }
+}
+
+impl Drop for Compiler {
+    fn drop(&mut self) {
+        unsafe { sc_internal_compiler_delete(self.sc_compiler); }
+    }
+}

--- a/spirv_cross/src/hlsl.rs
+++ b/spirv_cross/src/hlsl.rs
@@ -79,33 +79,56 @@ impl Default for CompilerOptions {
 
 #[derive(Debug, Clone)]
 pub struct Compiler {
-    _unconstructable: (),
+    base: spirv::Compiler,
 }
 
 impl Compiler {
-    pub fn new() -> Compiler {
-        Compiler { _unconstructable: () }
+    pub fn from_module(module: &spirv::Module) -> Result<Self, ErrorCode> {
+        let base = unsafe {
+            let mut compiler = ptr::null_mut();
+            check!(sc_internal_compiler_hlsl_new(
+                &mut compiler,
+                module.ir.as_ptr() as *const u32,
+                module.ir.len() as usize,
+            ));
+
+            spirv::Compiler {
+                sc_compiler: compiler,
+            }
+        };
+
+        Ok(Compiler { base })
+    }
+
+    pub fn get_decoration(&self, id: u32, decoration: spv::Decoration) -> Result<Option<u32>, ErrorCode> {
+        self.base.get_decoration(id, decoration)
+    }
+
+    pub fn set_decoration(&self, id: u32, decoration: spv::Decoration, argument: u32) -> Result<(), ErrorCode> {
+        self.base.set_decoration(id, decoration, argument)
+    }
+
+    pub fn get_entry_points(&self) -> Result<Vec<spirv::EntryPoint>, ErrorCode> {
+        self.base.get_entry_points()
+    }
+
+    fn set_options(&self, options: &CompilerOptions) -> Result<(), ErrorCode> {
+        let raw_options = options.as_raw();
+        unsafe {
+            check!(sc_internal_compiler_hlsl_set_options(
+                self.base.sc_compiler,
+                &raw_options,
+            ));
+        }
+
+        Ok(())
     }
 
     pub fn compile(
         &self,
-        parsed_module: &spirv::ParsedModule,
         options: &CompilerOptions,
     ) -> Result<String, ErrorCode> {
-        unsafe {
-            let mut hlsl_ptr = ptr::null();
-            check!(sc_internal_compiler_hlsl_compile(
-                parsed_module.ir.as_ptr() as *const u32,
-                parsed_module.ir.len() as usize,
-                &mut hlsl_ptr,
-                &options.as_raw(),
-            ));
-            let hlsl = match CStr::from_ptr(hlsl_ptr).to_owned().into_string() {
-                Err(_) => return Err(ErrorCode::Unhandled),
-                Ok(v) => v,
-            };
-            check!(sc_internal_free_pointer(hlsl_ptr as *mut c_void));
-            Ok(hlsl)
-        }
+        self.set_options(options)?;
+        self.base.compile()
     }
 }

--- a/spirv_cross/src/lib.rs
+++ b/spirv_cross/src/lib.rs
@@ -1,5 +1,8 @@
 macro_rules! check {
     ($check:expr) => {{
+        use std::ffi::CStr;
+        use std::os::raw::c_void;
+
         let result = $check;
         if ScInternalResult::Success != result {
             if ScInternalResult::CompilationError == result {
@@ -30,6 +33,8 @@ macro_rules! check {
         }
     }
 }}
+
+mod compiler;
 
 pub mod spirv;
 pub mod hlsl;

--- a/spirv_cross/src/msl.rs
+++ b/spirv_cross/src/msl.rs
@@ -1,9 +1,6 @@
-use super::ErrorCode;
-use spirv;
+use {compiler, spirv, ErrorCode};
 use bindings::root::*;
 use std::ptr;
-use std::ffi::CStr;
-use std::os::raw::c_void;
 
 #[derive(Debug, Clone)]
 pub struct CompilerVertexOptions {
@@ -41,40 +38,20 @@ impl Default for CompilerOptions {
 }
 
 #[derive(Debug, Clone)]
-pub struct Compiler {
-    base: spirv::Compiler,
+pub struct Compiler<'a> {
+    base: &'a compiler::Compiler,
 }
 
-impl Compiler {
-    pub fn from_module(module: &spirv::Module) -> Result<Self, ErrorCode> {
-        let base = unsafe {
-            let mut compiler = ptr::null_mut();
-            check!(sc_internal_compiler_msl_new(
-                &mut compiler,
-                module.ir.as_ptr() as *const u32,
-                module.ir.len() as usize,
-            ));
-
-            spirv::Compiler {
-                sc_compiler: compiler,
-            }
-        };
-
-        Ok(Compiler { base })
+impl<'a> Compiler<'a> {
+    /// Create a new MSL compiler from AST.
+    pub fn from_ast(ast: &'a spirv::Ast) -> Self {
+        assert_eq!(ast.target, spirv::Target::Msl);
+        Compiler {
+            base: &ast.compiler,
+        }
     }
 
-    pub fn get_decoration(&self, id: u32, decoration: spv::Decoration) -> Result<Option<u32>, ErrorCode> {
-        self.base.get_decoration(id, decoration)
-    }
-
-    pub fn set_decoration(&self, id: u32, decoration: spv::Decoration, argument: u32) -> Result<(), ErrorCode> {
-        self.base.set_decoration(id, decoration, argument)
-    }
-
-    pub fn get_entry_points(&self) -> Result<Vec<spirv::EntryPoint>, ErrorCode> {
-        self.base.get_entry_points()
-    }
-
+    /// Set MSL compiler specific compilation settings.
     fn set_options(&self, options: &CompilerOptions) -> Result<(), ErrorCode> {
         let raw_options = options.as_raw();
         unsafe {
@@ -87,6 +64,7 @@ impl Compiler {
         Ok(())
     }
 
+    /// Generate MSL shader from the AST.
     pub fn compile(
         &self,
         options: &CompilerOptions,

--- a/spirv_cross/src/spirv.rs
+++ b/spirv_cross/src/spirv.rs
@@ -1,8 +1,7 @@
-use super::ErrorCode;
+use ErrorCode;
 use bindings::root::*;
+use compiler;
 use std::ptr;
-use std::os::raw::c_void;
-use std::ffi::CStr;
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub enum ExecutionModel {
@@ -13,25 +12,6 @@ pub enum ExecutionModel {
     Fragment = 4,
     GlCompute = 5,
     Kernel = 6,
-}
-
-impl ExecutionModel {
-    fn from_raw(raw: spv::ExecutionModel) -> Result<ExecutionModel, ErrorCode> {
-        match raw {
-            spv::ExecutionModel::ExecutionModelVertex => Ok(ExecutionModel::Vertex),
-            spv::ExecutionModel::ExecutionModelTessellationControl => {
-                Ok(ExecutionModel::TessellationControl)
-            }
-            spv::ExecutionModel::ExecutionModelTessellationEvaluation => {
-                Ok(ExecutionModel::TessellationEvaluation)
-            }
-            spv::ExecutionModel::ExecutionModelGeometry => Ok(ExecutionModel::Geometry),
-            spv::ExecutionModel::ExecutionModelFragment => Ok(ExecutionModel::Fragment),
-            spv::ExecutionModel::ExecutionModelGLCompute => Ok(ExecutionModel::GlCompute),
-            spv::ExecutionModel::ExecutionModelKernel => Ok(ExecutionModel::Kernel),
-            _ => Err(ErrorCode::Unhandled),
-        }
-    }
 }
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
@@ -59,109 +39,56 @@ impl<'a> Module<'a> {
     }
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct Compiler {
-    pub sc_compiler: *mut ScInternalCompilerBase,
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+pub enum Target {
+    Hlsl,
+    Msl,
 }
 
-impl Compiler {
-    pub fn compile(&self) -> Result<String, ErrorCode> {
-        unsafe {
-            let mut shader_ptr = ptr::null();
-            check!(sc_internal_compiler_compile(
-                self.sc_compiler,
-                &mut shader_ptr,
-            ));
-            let shader = match CStr::from_ptr(shader_ptr).to_owned().into_string() {
-                Err(_) => return Err(ErrorCode::Unhandled),
-                Ok(v) => v,
-            };
-            check!(sc_internal_free_pointer(shader_ptr as *mut c_void));
-            Ok(shader)
-        }
-    }
+pub struct Ast {
+    pub(crate) target: Target,
+    pub(crate) compiler: compiler::Compiler,
+}
 
-    pub fn get_decoration(&self, id: u32, decoration: spv::Decoration) -> Result<Option<u32>, ErrorCode> {
-        let mut result = 0;
-        unsafe {
-            check!(sc_internal_compiler_get_decoration(
-                self.sc_compiler,
-                &mut result,
-                id,
-                decoration,
-            ));
-        }
+impl Ast {
+    pub fn parse(module: &Module, target: Target) -> Result<Self, ErrorCode> {
+        let compiler = {
+            let mut compiler = ptr::null_mut();
+            match target {
+                Target::Hlsl => unsafe {
+                    check!(sc_internal_compiler_hlsl_new(
+                        &mut compiler,
+                        module.ir.as_ptr() as *const u32,
+                        module.ir.len() as usize,
+                    ));
+                },
+                Target::Msl => unsafe {
+                    check!(sc_internal_compiler_msl_new(
+                        &mut compiler,
+                        module.ir.as_ptr() as *const u32,
+                        module.ir.len() as usize,
+                    ));
+                },
+            }
 
-        Ok(match result {
-            0 => None,
-            _ => Some(result),
+            compiler::Compiler { sc_compiler: compiler }
+        };
+
+        Ok(Ast {
+            compiler,
+            target,
         })
     }
 
-    pub fn set_decoration(&self, id: u32, decoration: spv::Decoration, argument: u32) -> Result<(), ErrorCode> {
-        unsafe {
-            check!(sc_internal_compiler_set_decoration(
-                self.sc_compiler,
-                id,
-                decoration,
-                argument,
-            ));
-        }
+    pub fn get_decoration(&self, id: u32, decoration: spv::Decoration) -> Result<Option<u32>, ErrorCode> {
+        self.compiler.get_decoration(id, decoration)
+    }
 
-        Ok(())
+    pub fn set_decoration(&self, id: u32, decoration: spv::Decoration, argument: u32) -> Result<(), ErrorCode> {
+        self.compiler.set_decoration(id, decoration, argument)
     }
 
     pub fn get_entry_points(&self) -> Result<Vec<EntryPoint>, ErrorCode> {
-        let mut entry_points_raw = ptr::null_mut();
-        let mut entry_points_raw_length = 0 as usize;
-
-        unsafe {
-            check!(sc_internal_compiler_get_entry_points(
-                self.sc_compiler,
-                &mut entry_points_raw,
-                &mut entry_points_raw_length,
-            ));
-
-            let entry_points = (0..entry_points_raw_length)
-                .map(|offset| {
-                    let entry_point_raw_ptr = entry_points_raw.offset(offset as isize);
-                    let entry_point_raw = *entry_point_raw_ptr;
-                    let name = match CStr::from_ptr(entry_point_raw.name)
-                        .to_owned()
-                        .into_string()
-                    {
-                        Ok(n) => n,
-                        _ => return Err(ErrorCode::Unhandled),
-                    };
-
-                    let entry_point = EntryPoint {
-                        name,
-                        execution_model: try!(
-                            ExecutionModel::from_raw(entry_point_raw.execution_model)
-                        ),
-                        workgroup_size: WorkgroupSize {
-                            x: entry_point_raw.workgroup_size_x,
-                            y: entry_point_raw.workgroup_size_y,
-                            z: entry_point_raw.workgroup_size_z,
-                        },
-                    };
-
-                    check!(sc_internal_free_pointer(
-                        entry_point_raw.name as *mut c_void,
-                    ));
-                    check!(sc_internal_free_pointer(entry_point_raw_ptr as *mut c_void));
-
-                    Ok(entry_point)
-                })
-                .collect::<Result<Vec<_>, _>>();
-
-            Ok(try!(entry_points))
-        }
-    }
-}
-
-impl Drop for Compiler {
-    fn drop(&mut self) {
-        unsafe { sc_internal_compiler_delete(self.sc_compiler); }
+        self.compiler.get_entry_points()
     }
 }

--- a/spirv_cross/src/wrapper.cpp
+++ b/spirv_cross/src/wrapper.cpp
@@ -37,23 +37,74 @@ ScInternalResult sc_internal_get_latest_exception_message(const char **message)
             *message = latest_exception_message;)
 }
 
-ScInternalResult sc_internal_compiler_base_parse(const uint32_t *ir, size_t size, ScEntryPoint **entry_points, size_t *entry_points_size)
+ScInternalResult sc_internal_compiler_hlsl_new(ScInternalCompilerHlsl **compiler, const uint32_t *ir, size_t size)
+{
+    INTERNAL_RESULT(*compiler = new spirv_cross::CompilerHLSL(ir, size);)
+}
+
+ScInternalResult sc_internal_compiler_hlsl_set_options(const ScInternalCompilerHlsl *compiler, const ScHlslCompilerOptions *options)
 {
     INTERNAL_RESULT(
         do {
             // Unsafe
-            spirv_cross::Compiler compiler(ir, size);
+            auto compiler_glsl = (spirv_cross::CompilerGLSL *)compiler;
+            auto glsl_options = compiler_glsl->spirv_cross::CompilerGLSL::get_options();
+            glsl_options.vertex.fixup_clipspace = options->vertex_transform_clip_space;
+            glsl_options.vertex.flip_vert_y = options->vertex_invert_y;
+            compiler_glsl->spirv_cross::CompilerGLSL::set_options(glsl_options);
+
+            auto compiler_hlsl = (spirv_cross::CompilerHLSL *)compiler;
+            auto hlsl_options = compiler_hlsl->get_options();
+            hlsl_options.shader_model = options->shader_model;
+            compiler_hlsl->set_options(hlsl_options);
+    } while (0);)
+}
+
+ScInternalResult sc_internal_compiler_msl_new(ScInternalCompilerMsl **compiler, const uint32_t *ir, size_t size)
+{
+    INTERNAL_RESULT(*compiler = new spirv_cross::CompilerMSL(ir, size);)
+}
+
+ScInternalResult sc_internal_compiler_msl_set_options(const ScInternalCompilerMsl *compiler, const ScMslCompilerOptions *options)
+{
+    INTERNAL_RESULT(
+        do {
+            // Unsafe
+            auto compiler_glsl = (spirv_cross::CompilerGLSL *)compiler;
+            auto glsl_options = compiler_glsl->spirv_cross::CompilerGLSL::get_options();
+            glsl_options.vertex.fixup_clipspace = options->vertex_transform_clip_space;
+            glsl_options.vertex.flip_vert_y = options->vertex_invert_y;
+            compiler_glsl->spirv_cross::CompilerGLSL::set_options(glsl_options);
+    } while (0);)
+}
+
+ScInternalResult sc_internal_compiler_get_decoration(const ScInternalCompilerBase *compiler, uint32_t *result, uint32_t id, spv::Decoration decoration)
+{
+    INTERNAL_RESULT(*result = ((spirv_cross::Compiler *)compiler)->get_decoration(id, decoration);)
+}
+
+ScInternalResult sc_internal_compiler_set_decoration(const ScInternalCompilerBase *compiler, uint32_t id, spv::Decoration decoration, uint32_t argument)
+{
+    INTERNAL_RESULT(((spirv_cross::Compiler *)compiler)->set_decoration(id, decoration, argument);)
+}
+
+ScInternalResult sc_internal_compiler_get_entry_points(const ScInternalCompilerBase *comp, ScEntryPoint **entry_points, size_t *size)
+{
+    INTERNAL_RESULT(
+        do {
+            // Unsafe
+            auto const &compiler = *((spirv_cross::Compiler *)comp);
             auto const &sc_entry_point_names = compiler.get_entry_points();
             auto const sc_size = sc_entry_point_names.size();
-            auto const &sc_entry_points = std::make_unique<spirv_cross::SPIREntryPoint[]>(size);
+            auto const &sc_entry_points = std::make_unique<spirv_cross::SPIREntryPoint[]>(sc_size);
             for (uint32_t i = 0; i < sc_size; i++)
             {
                 sc_entry_points[i] = compiler.get_entry_point(sc_entry_point_names[i]);
             }
 
             // Release to FFI
-            *entry_points = (ScEntryPoint *)malloc(size * sizeof(ScEntryPoint));
-            *entry_points_size = sc_size;
+            *entry_points = (ScEntryPoint *)malloc(sc_size * sizeof(ScEntryPoint));
+            *size = sc_size;
             for (uint32_t i = 0; i < sc_size; i++)
             {
                 auto const &sc_entry_point = sc_entry_points[i];
@@ -67,46 +118,19 @@ ScInternalResult sc_internal_compiler_base_parse(const uint32_t *ir, size_t size
         } while (0);)
 }
 
-ScInternalResult sc_internal_compiler_hlsl_compile(const uint32_t *ir, size_t size, const char **hlsl, const ScHlslCompilerOptions *options)
+ScInternalResult sc_internal_compiler_compile(const ScInternalCompilerBase *compiler, const char **shader)
 {
     INTERNAL_RESULT(
         do {
             // Unsafe
-            spirv_cross::CompilerHLSL compiler(ir, size);
-
-            auto glsl_options = compiler.spirv_cross::CompilerGLSL::get_options();
-            glsl_options.vertex.fixup_clipspace = options->vertex_transform_clip_space;
-            glsl_options.vertex.flip_vert_y = options->vertex_invert_y;
-            compiler.spirv_cross::CompilerGLSL::set_options(glsl_options);
-
-            auto hlsl_options = compiler.get_options();
-            hlsl_options.shader_model = options->shader_model;
-            compiler.set_options(hlsl_options);
-
-            auto const &compiled = compiler.compile();
-
             // Release to FFI
-            *hlsl = strdup(strdup(compiled.c_str()));
+            *shader = strdup(strdup(((spirv_cross::Compiler *)compiler)->compile().c_str()));
         } while (0);)
 }
 
-ScInternalResult sc_internal_compiler_msl_compile(const uint32_t *ir, size_t size, const char **msl, const ScMslCompilerOptions *options)
+ScInternalResult sc_internal_compiler_delete(ScInternalCompilerBase *compiler)
 {
-    INTERNAL_RESULT(
-        do {
-            // Unsafe
-            spirv_cross::CompilerMSL compiler(ir, size);
-
-            auto glsl_options = compiler.spirv_cross::CompilerGLSL::get_options();
-            glsl_options.vertex.fixup_clipspace = options->vertex_transform_clip_space;
-            glsl_options.vertex.flip_vert_y = options->vertex_invert_y;
-            compiler.spirv_cross::CompilerGLSL::set_options(glsl_options);
-
-            auto const &compiled = compiler.compile();
-
-            // Release to FFI
-            *msl = strdup(strdup(compiled.c_str()));
-        } while (0);)
+    INTERNAL_RESULT(delete (spirv_cross::Compiler *)compiler;)
 }
 
 ScInternalResult sc_internal_free_pointer(void *pointer)

--- a/spirv_cross/src/wrapper.hpp
+++ b/spirv_cross/src/wrapper.hpp
@@ -3,6 +3,7 @@
 
 typedef void ScInternalCompilerBase;
 typedef void ScInternalCompilerHlsl;
+typedef void ScInternalCompilerMsl;
 
 extern "C" {
 
@@ -37,11 +38,17 @@ typedef struct ScMslCompilerOptions
 
 ScInternalResult sc_internal_get_latest_exception_message(const char **message);
 
-ScInternalResult sc_internal_compiler_base_parse(const uint32_t *ir, size_t size, ScEntryPoint **entry_points, size_t *entry_points_size);
+ScInternalResult sc_internal_compiler_hlsl_new(ScInternalCompilerHlsl **compiler, const uint32_t *ir, size_t size);
+ScInternalResult sc_internal_compiler_hlsl_set_options(const ScInternalCompilerHlsl *compiler, const ScHlslCompilerOptions *options);
 
-ScInternalResult sc_internal_compiler_hlsl_compile(const uint32_t *ir, size_t size, const char **hlsl, const ScHlslCompilerOptions *options);
+ScInternalResult sc_internal_compiler_msl_new(ScInternalCompilerMsl **compiler, const uint32_t *ir, size_t size);
+ScInternalResult sc_internal_compiler_msl_set_options(const ScInternalCompilerHlsl *compiler, const ScMslCompilerOptions *options);
 
-ScInternalResult sc_internal_compiler_msl_compile(const uint32_t *ir, size_t size, const char **msl, const ScMslCompilerOptions *options);
+ScInternalResult sc_internal_compiler_get_decoration(const ScInternalCompilerBase *compiler, uint32_t *result, uint32_t id, spv::Decoration decoration);
+ScInternalResult sc_internal_compiler_set_decoration(const ScInternalCompilerBase *compiler, uint32_t id, spv::Decoration decoration, uint32_t argument);
+ScInternalResult sc_internal_compiler_get_entry_points(const ScInternalCompilerBase *compiler, ScEntryPoint **entry_points, size_t *size);
+ScInternalResult sc_internal_compiler_compile(const ScInternalCompilerBase *compiler, const char **shader);
+ScInternalResult sc_internal_compiler_delete(ScInternalCompilerBase *compiler);
 
 ScInternalResult sc_internal_free_pointer(void *pointer);
 }


### PR DESCRIPTION
* Adapt the API to better fit the C++ API, which should allow to easier extend the library. Current API would require reparsing the module multiple times (e.g set/get decorations).
This mostly reverts the changes from #https://github.com/grovesNL/spirv_cross/pull/4

* Added new `set/get_decoration` functions, which are needed for patching the HLSL output in gfx-rs.