### PR TITLE
Use generic `Ast` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,12 @@ use spirv_cross::{spirv, hlsl, msl, ErrorCode};
 
 fn example(module: spirv::Module) -> Result<(), ErrorCode> {
     // Compile to HLSL
-    let ast = spirv::Ast::parse(&module, spirv::Target::Hlsl)?;
-    let hlsl = hlsl::Compiler::from_ast(&ast)
-        .compile(&hlsl::CompilerOptions::default())?;
-
-    println!("{}", hlsl);
+    let ast = spirv::Ast::<hlsl::Target>::parse(&module)?;
+    println!("{}", ast.compile()?);
 
     // Compile to MSL
-    let ast = spirv::Ast::parse(&module, spirv::Target::Msl)?;
-    let msl = msl::Compiler::from_ast(&ast)
-        .compile(&msl::CompilerOptions::default())?;
-
-    println!("{}", msl);
+    let ast = spirv::Ast::<msl::Target>::parse(&module)?;
+    println!("{}", ast.compile()?);
 
     Ok(())
 }

--- a/examples/src/hlsl/main.rs
+++ b/examples/src/hlsl/main.rs
@@ -1,5 +1,5 @@
 extern crate spirv_cross;
-use spirv_cross::{spirv, hlsl};
+use spirv_cross::{hlsl, spirv};
 
 fn ir_words_from_bytes(buf: &[u8]) -> &[u32] {
     unsafe {
@@ -14,7 +14,7 @@ fn main() {
     let vertex_module = spirv::Module::new(ir_words_from_bytes(include_bytes!("vertex.spv")));
 
     // Parse a SPIR-V module
-    let ast = spirv::Ast::parse(&vertex_module, spirv::Target::Hlsl).unwrap();
+    let ast = spirv::Ast::<hlsl::Target>::parse(&vertex_module).unwrap();
 
     // List all entry points
     for entry_point in &ast.get_entry_points().unwrap() {
@@ -22,9 +22,6 @@ fn main() {
     }
 
     // Compile to HLSL
-    let hlsl = hlsl::Compiler::from_ast(&ast)
-        .compile(&hlsl::CompilerOptions::default())
-        .unwrap();
-
-    println!("{}", hlsl);
+    let shader = ast.compile().unwrap();
+    println!("{}", shader);
 }

--- a/examples/src/msl/main.rs
+++ b/examples/src/msl/main.rs
@@ -14,7 +14,7 @@ fn main() {
     let vertex_module = spirv::Module::new(ir_words_from_bytes(include_bytes!("vertex.spv")));
 
     // Parse a SPIR-V module
-    let ast = spirv::Ast::parse(&vertex_module, spirv::Target::Msl).unwrap();
+    let ast = spirv::Ast::<msl::Target>::parse(&vertex_module).unwrap();
 
     // List all entry points
     for entry_point in &ast.get_entry_points().unwrap() {
@@ -22,9 +22,6 @@ fn main() {
     }
 
     // Compile to MSL
-    let msl = msl::Compiler::from_ast(&ast)
-        .compile(&msl::CompilerOptions::default())
-        .unwrap();
-
-    println!("{}", msl);
+    let shader = ast.compile().unwrap();
+    println!("{}", shader);
 }

--- a/spirv_cross/Cargo.toml
+++ b/spirv_cross/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirv_cross"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Joshua Groves <josh@joshgroves.com>"]
 description = "Safe wrapper around SPIRV-Cross"
 license = "Apache-2.0"

--- a/spirv_cross/src/compiler.rs
+++ b/spirv_cross/src/compiler.rs
@@ -12,12 +12,8 @@ impl spirv::ExecutionModel {
         use spirv::ExecutionModel::*;
         match raw {
             spv::ExecutionModel::ExecutionModelVertex => Ok(Vertex),
-            spv::ExecutionModel::ExecutionModelTessellationControl => {
-                Ok(TessellationControl)
-            }
-            spv::ExecutionModel::ExecutionModelTessellationEvaluation => {
-                Ok(TessellationEvaluation)
-            }
+            spv::ExecutionModel::ExecutionModelTessellationControl => Ok(TessellationControl),
+            spv::ExecutionModel::ExecutionModelTessellationEvaluation => Ok(TessellationEvaluation),
             spv::ExecutionModel::ExecutionModelGeometry => Ok(Geometry),
             spv::ExecutionModel::ExecutionModelFragment => Ok(Fragment),
             spv::ExecutionModel::ExecutionModelGLCompute => Ok(GlCompute),
@@ -49,7 +45,11 @@ impl Compiler {
         }
     }
 
-    pub fn get_decoration(&self, id: u32, decoration: spv::Decoration) -> Result<Option<u32>, ErrorCode> {
+    pub fn get_decoration(
+        &self,
+        id: u32,
+        decoration: spv::Decoration,
+    ) -> Result<Option<u32>, ErrorCode> {
         let mut result = 0;
         unsafe {
             check!(sc_internal_compiler_get_decoration(
@@ -66,7 +66,12 @@ impl Compiler {
         })
     }
 
-    pub fn set_decoration(&self, id: u32, decoration: spv::Decoration, argument: u32) -> Result<(), ErrorCode> {
+    pub fn set_decoration(
+        &mut self,
+        id: u32,
+        decoration: spv::Decoration,
+        argument: u32,
+    ) -> Result<(), ErrorCode> {
         unsafe {
             check!(sc_internal_compiler_set_decoration(
                 self.sc_compiler,
@@ -104,9 +109,9 @@ impl Compiler {
 
                     let entry_point = spirv::EntryPoint {
                         name,
-                        execution_model: try!(
-                            spirv::ExecutionModel::from_raw(entry_point_raw.execution_model)
-                        ),
+                        execution_model: try!(spirv::ExecutionModel::from_raw(
+                            entry_point_raw.execution_model
+                        )),
                         workgroup_size: spirv::WorkgroupSize {
                             x: entry_point_raw.workgroup_size_x,
                             y: entry_point_raw.workgroup_size_y,
@@ -130,6 +135,8 @@ impl Compiler {
 
 impl Drop for Compiler {
     fn drop(&mut self) {
-        unsafe { sc_internal_compiler_delete(self.sc_compiler); }
+        unsafe {
+            sc_internal_compiler_delete(self.sc_compiler);
+        }
     }
 }

--- a/spirv_cross/src/hlsl.rs
+++ b/spirv_cross/src/hlsl.rs
@@ -1,6 +1,10 @@
 use {compiler, spirv, ErrorCode};
 use bindings::root::*;
 use std::ptr;
+use std::marker::PhantomData;
+
+#[derive(Debug, Clone)]
+pub struct Target;
 
 #[allow(non_snake_case, non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
@@ -74,26 +78,39 @@ impl Default for CompilerOptions {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct Compiler<'a> {
-    base: &'a compiler::Compiler,
+impl spirv::Parse<Target> for spirv::Ast<Target> {
+    fn parse(module: &spirv::Module) -> Result<Self, ErrorCode> {
+        let compiler = {
+            let mut compiler = ptr::null_mut();
+            unsafe {
+                check!(sc_internal_compiler_hlsl_new(
+                    &mut compiler,
+                    module.ir.as_ptr() as *const u32,
+                    module.ir.len() as usize,
+                ));
+            }
+
+            compiler::Compiler {
+                sc_compiler: compiler,
+            }
+        };
+
+        Ok(spirv::Ast {
+            compiler,
+            target_type: PhantomData,
+        })
+    }
 }
 
-impl<'a> Compiler<'a> {
-    /// Create a new HLSL compiler from AST.
-    pub fn from_ast(ast: &'a spirv::Ast) -> Self {
-        assert_eq!(ast.target, spirv::Target::Hlsl);
-        Compiler {
-            base: &ast.compiler,
-        }
-    }
+impl spirv::Compile<Target> for spirv::Ast<Target> {
+    type CompilerOptions = CompilerOptions;
 
     /// Set HLSL compiler specific compilation settings.
-    fn set_options(&self, options: &CompilerOptions) -> Result<(), ErrorCode> {
+    fn set_compile_options(&mut self, options: &CompilerOptions) -> Result<(), ErrorCode> {
         let raw_options = options.as_raw();
         unsafe {
             check!(sc_internal_compiler_hlsl_set_options(
-                self.base.sc_compiler,
+                self.compiler.sc_compiler,
                 &raw_options,
             ));
         }
@@ -102,11 +119,7 @@ impl<'a> Compiler<'a> {
     }
 
     /// Generate HLSL shader from the AST.
-    pub fn compile(
-        &self,
-        options: &CompilerOptions,
-    ) -> Result<String, ErrorCode> {
-        self.set_options(options)?;
-        self.base.compile()
+    fn compile(&self) -> Result<String, ErrorCode> {
+        self.compiler.compile()
     }
 }


### PR DESCRIPTION
Testing out the idea in #10 to use generic methods instead.