### PR TITLE
Refactor #24

### DIFF
--- a/bindings_generator/src/main.rs
+++ b/bindings_generator/src/main.rs
@@ -13,6 +13,8 @@ fn main() {
         .whitelisted_type("spv::.*")
         .bitfield_enum(".*(Mask|Flags)")
         .whitelisted_type("spirv_cross::Resource")
+        .whitelisted_type("spirv_cross::MSLVertexAttr")
+        .whitelisted_type("spirv_cross::MSLResourceBinding")
         .opaque_type("std::.*")
         .generate()
         .expect("Unable to generate bindings")

--- a/examples/src/hlsl/main.rs
+++ b/examples/src/hlsl/main.rs
@@ -7,8 +7,8 @@ fn main() {
     let module = spirv::Module::from_words(words_from_bytes(include_bytes!("../vertex.spv")));
 
     // Parse a SPIR-V module
-    let mut ast = spirv::Ast::<hlsl::Target>::parse(&module).unwrap();
-    ast.set_compile_options(hlsl::CompilerOptions {
+    let mut ast = spirv::Ast::<hlsl::Target>::parse(&module, &hlsl::ParserOptions::default()).unwrap();
+    ast.set_compile_options(&hlsl::CompilerOptions {
         shader_model: hlsl::ShaderModel::V5_1,
         vertex: hlsl::CompilerVertexOptions::default(),
     }).unwrap();

--- a/examples/src/hlsl/main.rs
+++ b/examples/src/hlsl/main.rs
@@ -7,8 +7,8 @@ fn main() {
     let module = spirv::Module::from_words(words_from_bytes(include_bytes!("../vertex.spv")));
 
     // Parse a SPIR-V module
-    let mut ast = spirv::Ast::<hlsl::Target>::parse(&module, &hlsl::ParserOptions::default()).unwrap();
-    ast.set_compile_options(&hlsl::CompilerOptions {
+    let mut ast = spirv::Ast::<hlsl::Target>::parse(&module).unwrap();
+    ast.set_compiler_options(&hlsl::CompilerOptions {
         shader_model: hlsl::ShaderModel::V5_1,
         vertex: hlsl::CompilerVertexOptions::default(),
     }).unwrap();

--- a/examples/src/msl/main.rs
+++ b/examples/src/msl/main.rs
@@ -6,8 +6,32 @@ use examples::words_from_bytes;
 fn main() {
     let module = spirv::Module::from_words(words_from_bytes(include_bytes!("../vertex.spv")));
 
+    // Build parser options with some overrides
+    let mut parser_options = msl::ParserOptions::default();
+    parser_options.vertex_attribute_overrides.insert(
+        msl::VertexAttributeLocation(1),
+        msl::VertexAttribute {
+            buffer_id: 1,
+            offset: 2,
+            stride: 3,
+            step: spirv::VertexAttributeStep::Instance,
+            force_used: true,
+        },
+    );
+    parser_options.resource_binding_overrides.insert(
+        msl::ResourceBindingLocation {
+            stage: spirv::ExecutionModel::Vertex,
+            desc_set: 0,
+            binding: 0,
+        },
+        msl::ResourceBinding {
+            resource_id: 5,
+            force_used: false,
+        },
+    );
+
     // Parse a SPIR-V module
-    let ast = spirv::Ast::<msl::Target>::parse(&module).unwrap();
+    let ast = spirv::Ast::<msl::Target>::parse(&module, &parser_options).unwrap();
 
     // List all entry points
     for entry_point in &ast.get_entry_points().unwrap() {

--- a/examples/src/msl/main.rs
+++ b/examples/src/msl/main.rs
@@ -1,24 +1,18 @@
-extern crate spirv_cross;
 extern crate examples;
+extern crate spirv_cross;
 use spirv_cross::{msl, spirv};
 use examples::words_from_bytes;
 
 fn main() {
     let module = spirv::Module::from_words(words_from_bytes(include_bytes!("../vertex.spv")));
 
-    // Build parser options with some overrides
-    let mut parser_options = msl::ParserOptions::default();
-    parser_options.vertex_attribute_overrides.insert(
-        msl::VertexAttributeLocation(1),
-        msl::VertexAttribute {
-            buffer_id: 1,
-            offset: 2,
-            stride: 3,
-            step: spirv::VertexAttributeStep::Instance,
-            force_used: true,
-        },
-    );
-    parser_options.resource_binding_overrides.insert(
+    // Parse a SPIR-V module
+    let mut ast = spirv::Ast::<msl::Target>::parse(&module).unwrap();
+
+    let mut compiler_options = msl::CompilerOptions::default();
+
+    // Set some overrides
+    compiler_options.resource_binding_overrides.insert(
         msl::ResourceBindingLocation {
             stage: spirv::ExecutionModel::Vertex,
             desc_set: 0,
@@ -30,8 +24,18 @@ fn main() {
         },
     );
 
-    // Parse a SPIR-V module
-    let ast = spirv::Ast::<msl::Target>::parse(&module, &parser_options).unwrap();
+    compiler_options.vertex_attribute_overrides.insert(
+        msl::VertexAttributeLocation(1),
+        msl::VertexAttribute {
+            buffer_id: 1,
+            offset: 2,
+            stride: 3,
+            step: spirv::VertexAttributeStep::Instance,
+            force_used: true,
+        },
+    );
+
+    ast.set_compiler_options(&compiler_options).unwrap();
 
     // List all entry points
     for entry_point in &ast.get_entry_points().unwrap() {

--- a/spirv_cross/Cargo.toml
+++ b/spirv_cross/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirv_cross"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Joshua Groves <josh@joshgroves.com>"]
 description = "Safe wrapper around SPIRV-Cross"
 license = "Apache-2.0"

--- a/spirv_cross/src/bindings.rs
+++ b/spirv_cross/src/bindings.rs
@@ -8,7 +8,7 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         pub type Id = ::std::os::raw::c_uint;
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum SourceLanguage {
             SourceLanguageUnknown = 0,
@@ -19,7 +19,7 @@ pub mod root {
             SourceLanguageHLSL = 5,
             SourceLanguageMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum ExecutionModel {
             ExecutionModelVertex = 0,
@@ -31,7 +31,7 @@ pub mod root {
             ExecutionModelKernel = 6,
             ExecutionModelMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum AddressingModel {
             AddressingModelLogical = 0,
@@ -39,7 +39,7 @@ pub mod root {
             AddressingModelPhysical64 = 2,
             AddressingModelMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum MemoryModel {
             MemoryModelSimple = 0,
@@ -47,7 +47,7 @@ pub mod root {
             MemoryModelOpenCL = 2,
             MemoryModelMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum ExecutionMode {
             ExecutionModeInvocations = 0,
@@ -83,7 +83,7 @@ pub mod root {
             ExecutionModeContractionOff = 31,
             ExecutionModeMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum StorageClass {
             StorageClassUniformConstant = 0,
@@ -101,7 +101,7 @@ pub mod root {
             StorageClassStorageBuffer = 12,
             StorageClassMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum Dim {
             Dim1D = 0,
@@ -113,7 +113,7 @@ pub mod root {
             DimSubpassData = 6,
             DimMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum SamplerAddressingMode {
             SamplerAddressingModeNone = 0,
@@ -123,14 +123,14 @@ pub mod root {
             SamplerAddressingModeRepeatMirrored = 4,
             SamplerAddressingModeMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum SamplerFilterMode {
             SamplerFilterModeNearest = 0,
             SamplerFilterModeLinear = 1,
             SamplerFilterModeMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum ImageFormat {
             ImageFormatUnknown = 0,
@@ -175,7 +175,7 @@ pub mod root {
             ImageFormatR8ui = 39,
             ImageFormatMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum ImageChannelOrder {
             ImageChannelOrderR = 0,
@@ -200,7 +200,7 @@ pub mod root {
             ImageChannelOrderABGR = 19,
             ImageChannelOrderMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum ImageChannelDataType {
             ImageChannelDataTypeSnormInt8 = 0,
@@ -222,7 +222,7 @@ pub mod root {
             ImageChannelDataTypeUnormInt101010_2 = 16,
             ImageChannelDataTypeMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum ImageOperandsShift {
             ImageOperandsBiasShift = 0,
@@ -298,8 +298,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct ImageOperandsMask(pub ::std::os::raw::c_int);
-        #[repr(i32)]
+        pub struct ImageOperandsMask(pub ::std::os::raw::c_uint);
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum FPFastMathModeShift {
             FPFastMathModeNotNaNShift = 0,
@@ -363,8 +363,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct FPFastMathModeMask(pub ::std::os::raw::c_int);
-        #[repr(i32)]
+        pub struct FPFastMathModeMask(pub ::std::os::raw::c_uint);
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum FPRoundingMode {
             FPRoundingModeRTE = 0,
@@ -373,14 +373,14 @@ pub mod root {
             FPRoundingModeRTN = 3,
             FPRoundingModeMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum LinkageType {
             LinkageTypeExport = 0,
             LinkageTypeImport = 1,
             LinkageTypeMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum AccessQualifier {
             AccessQualifierReadOnly = 0,
@@ -388,7 +388,7 @@ pub mod root {
             AccessQualifierReadWrite = 2,
             AccessQualifierMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum FunctionParameterAttribute {
             FunctionParameterAttributeZext = 0,
@@ -401,7 +401,7 @@ pub mod root {
             FunctionParameterAttributeNoReadWrite = 7,
             FunctionParameterAttributeMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum Decoration {
             DecorationRelaxedPrecision = 0,
@@ -453,7 +453,7 @@ pub mod root {
             DecorationSecondaryViewportRelativeNV = 5256,
             DecorationMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum BuiltIn {
             BuiltInPosition = 0,
@@ -514,7 +514,7 @@ pub mod root {
             BuiltInViewportMaskPerViewNV = 5262,
             BuiltInMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum SelectionControlShift {
             SelectionControlFlattenShift = 0,
@@ -567,8 +567,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct SelectionControlMask(pub ::std::os::raw::c_int);
-        #[repr(i32)]
+        pub struct SelectionControlMask(pub ::std::os::raw::c_uint);
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum LoopControlShift {
             LoopControlUnrollShift = 0,
@@ -620,8 +620,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct LoopControlMask(pub ::std::os::raw::c_int);
-        #[repr(i32)]
+        pub struct LoopControlMask(pub ::std::os::raw::c_uint);
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum FunctionControlShift {
             FunctionControlInlineShift = 0,
@@ -681,8 +681,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct FunctionControlMask(pub ::std::os::raw::c_int);
-        #[repr(i32)]
+        pub struct FunctionControlMask(pub ::std::os::raw::c_uint);
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum MemorySemanticsShift {
             MemorySemanticsAcquireShift = 1,
@@ -766,8 +766,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct MemorySemanticsMask(pub ::std::os::raw::c_int);
-        #[repr(i32)]
+        pub struct MemorySemanticsMask(pub ::std::os::raw::c_uint);
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum MemoryAccessShift {
             MemoryAccessVolatileShift = 0,
@@ -823,8 +823,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct MemoryAccessMask(pub ::std::os::raw::c_int);
-        #[repr(i32)]
+        pub struct MemoryAccessMask(pub ::std::os::raw::c_uint);
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum Scope {
             ScopeCrossDevice = 0,
@@ -834,7 +834,7 @@ pub mod root {
             ScopeInvocation = 4,
             ScopeMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum GroupOperation {
             GroupOperationReduce = 0,
@@ -890,8 +890,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct KernelEnqueueFlags(pub ::std::os::raw::c_int);
-        #[repr(i32)]
+        pub struct KernelEnqueueFlags(pub ::std::os::raw::c_uint);
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum KernelProfilingInfoShift {
             KernelProfilingInfoCmdExecTimeShift = 0,
@@ -941,14 +941,14 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct KernelProfilingInfoMask(pub ::std::os::raw::c_int);
+        pub struct KernelProfilingInfoMask(pub ::std::os::raw::c_uint);
         pub const Capability_CapabilityStorageUniformBufferBlock16:
                   root::spv::Capability =
             Capability::CapabilityStorageBuffer16BitAccess;
         pub const Capability_CapabilityUniformAndStorageBuffer16BitAccess:
                   root::spv::Capability =
             Capability::CapabilityStorageUniform16;
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum Capability {
             CapabilityMatrix = 0,
@@ -1026,7 +1026,7 @@ pub mod root {
             CapabilityPerViewAttributesNV = 5260,
             CapabilityMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum Op {
             OpNop = 0,
@@ -1335,12 +1335,9 @@ pub mod root {
     pub mod std {
         #[allow(unused_imports)]
         use self::super::super::root;
-        pub mod tr1 {
-            #[allow(unused_imports)]
-            use self::super::super::super::root;
-        }
-        pub type string = [u64; 4usize];
+        pub type string = [u64; 3usize];
     }
+    pub type __darwin_size_t = ::std::os::raw::c_ulong;
     pub mod spirv_cross {
         #[allow(unused_imports)]
         use self::super::super::root;
@@ -1354,7 +1351,7 @@ pub mod root {
         }
         #[test]
         fn bindgen_test_layout_Resource() {
-            assert_eq!(::std::mem::size_of::<Resource>() , 48usize , concat !
+            assert_eq!(::std::mem::size_of::<Resource>() , 40usize , concat !
                        ( "Size of: " , stringify ! ( Resource ) ));
             assert_eq! (::std::mem::align_of::<Resource>() , 8usize , concat !
                         ( "Alignment of " , stringify ! ( Resource ) ));
@@ -1382,11 +1379,134 @@ pub mod root {
         impl Clone for Resource {
             fn clone(&self) -> Self { *self }
         }
+        #[repr(C)]
+        #[derive(Debug, Copy)]
+        pub struct MSLVertexAttr {
+            pub location: u32,
+            pub msl_buffer: u32,
+            pub msl_offset: u32,
+            pub msl_stride: u32,
+            pub per_instance: bool,
+            pub used_by_shader: bool,
+        }
+        #[test]
+        fn bindgen_test_layout_MSLVertexAttr() {
+            assert_eq!(::std::mem::size_of::<MSLVertexAttr>() , 20usize ,
+                       concat ! ( "Size of: " , stringify ! ( MSLVertexAttr )
+                       ));
+            assert_eq! (::std::mem::align_of::<MSLVertexAttr>() , 4usize ,
+                        concat ! (
+                        "Alignment of " , stringify ! ( MSLVertexAttr ) ));
+            assert_eq! (unsafe {
+                        & ( * ( 0 as * const MSLVertexAttr ) ) . location as *
+                        const _ as usize } , 0usize , concat ! (
+                        "Alignment of field: " , stringify ! ( MSLVertexAttr )
+                        , "::" , stringify ! ( location ) ));
+            assert_eq! (unsafe {
+                        & ( * ( 0 as * const MSLVertexAttr ) ) . msl_buffer as
+                        * const _ as usize } , 4usize , concat ! (
+                        "Alignment of field: " , stringify ! ( MSLVertexAttr )
+                        , "::" , stringify ! ( msl_buffer ) ));
+            assert_eq! (unsafe {
+                        & ( * ( 0 as * const MSLVertexAttr ) ) . msl_offset as
+                        * const _ as usize } , 8usize , concat ! (
+                        "Alignment of field: " , stringify ! ( MSLVertexAttr )
+                        , "::" , stringify ! ( msl_offset ) ));
+            assert_eq! (unsafe {
+                        & ( * ( 0 as * const MSLVertexAttr ) ) . msl_stride as
+                        * const _ as usize } , 12usize , concat ! (
+                        "Alignment of field: " , stringify ! ( MSLVertexAttr )
+                        , "::" , stringify ! ( msl_stride ) ));
+            assert_eq! (unsafe {
+                        & ( * ( 0 as * const MSLVertexAttr ) ) . per_instance
+                        as * const _ as usize } , 16usize , concat ! (
+                        "Alignment of field: " , stringify ! ( MSLVertexAttr )
+                        , "::" , stringify ! ( per_instance ) ));
+            assert_eq! (unsafe {
+                        & ( * ( 0 as * const MSLVertexAttr ) ) .
+                        used_by_shader as * const _ as usize } , 17usize ,
+                        concat ! (
+                        "Alignment of field: " , stringify ! ( MSLVertexAttr )
+                        , "::" , stringify ! ( used_by_shader ) ));
+        }
+        impl Clone for MSLVertexAttr {
+            fn clone(&self) -> Self { *self }
+        }
+        #[repr(C)]
+        #[derive(Debug, Copy)]
+        pub struct MSLResourceBinding {
+            pub stage: root::spv::ExecutionModel,
+            pub desc_set: u32,
+            pub binding: u32,
+            pub msl_buffer: u32,
+            pub msl_texture: u32,
+            pub msl_sampler: u32,
+            pub used_by_shader: bool,
+        }
+        #[test]
+        fn bindgen_test_layout_MSLResourceBinding() {
+            assert_eq!(::std::mem::size_of::<MSLResourceBinding>() , 28usize ,
+                       concat ! (
+                       "Size of: " , stringify ! ( MSLResourceBinding ) ));
+            assert_eq! (::std::mem::align_of::<MSLResourceBinding>() , 4usize
+                        , concat ! (
+                        "Alignment of " , stringify ! ( MSLResourceBinding )
+                        ));
+            assert_eq! (unsafe {
+                        & ( * ( 0 as * const MSLResourceBinding ) ) . stage as
+                        * const _ as usize } , 0usize , concat ! (
+                        "Alignment of field: " , stringify ! (
+                        MSLResourceBinding ) , "::" , stringify ! ( stage )
+                        ));
+            assert_eq! (unsafe {
+                        & ( * ( 0 as * const MSLResourceBinding ) ) . desc_set
+                        as * const _ as usize } , 4usize , concat ! (
+                        "Alignment of field: " , stringify ! (
+                        MSLResourceBinding ) , "::" , stringify ! ( desc_set )
+                        ));
+            assert_eq! (unsafe {
+                        & ( * ( 0 as * const MSLResourceBinding ) ) . binding
+                        as * const _ as usize } , 8usize , concat ! (
+                        "Alignment of field: " , stringify ! (
+                        MSLResourceBinding ) , "::" , stringify ! ( binding )
+                        ));
+            assert_eq! (unsafe {
+                        & ( * ( 0 as * const MSLResourceBinding ) ) .
+                        msl_buffer as * const _ as usize } , 12usize , concat
+                        ! (
+                        "Alignment of field: " , stringify ! (
+                        MSLResourceBinding ) , "::" , stringify ! ( msl_buffer
+                        ) ));
+            assert_eq! (unsafe {
+                        & ( * ( 0 as * const MSLResourceBinding ) ) .
+                        msl_texture as * const _ as usize } , 16usize , concat
+                        ! (
+                        "Alignment of field: " , stringify ! (
+                        MSLResourceBinding ) , "::" , stringify ! (
+                        msl_texture ) ));
+            assert_eq! (unsafe {
+                        & ( * ( 0 as * const MSLResourceBinding ) ) .
+                        msl_sampler as * const _ as usize } , 20usize , concat
+                        ! (
+                        "Alignment of field: " , stringify ! (
+                        MSLResourceBinding ) , "::" , stringify ! (
+                        msl_sampler ) ));
+            assert_eq! (unsafe {
+                        & ( * ( 0 as * const MSLResourceBinding ) ) .
+                        used_by_shader as * const _ as usize } , 24usize ,
+                        concat ! (
+                        "Alignment of field: " , stringify ! (
+                        MSLResourceBinding ) , "::" , stringify ! (
+                        used_by_shader ) ));
+        }
+        impl Clone for MSLResourceBinding {
+            fn clone(&self) -> Self { *self }
+        }
     }
     pub type ScInternalCompilerBase = ::std::os::raw::c_void;
     pub type ScInternalCompilerHlsl = ::std::os::raw::c_void;
     pub type ScInternalCompilerMsl = ::std::os::raw::c_void;
-    #[repr(i32)]
+    #[repr(u32)]
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
     pub enum ScInternalResult {
         Success = 0,
@@ -1686,7 +1806,13 @@ pub mod root {
     extern "C" {
         pub fn sc_internal_compiler_msl_new(compiler:
                                                 *mut *mut root::ScInternalCompilerMsl,
-                                            ir: *const u32, size: usize)
+                                            ir: *const u32, size: usize,
+                                            p_vat_overrides:
+                                                *const root::spirv_cross::MSLVertexAttr,
+                                            vat_override_count: usize,
+                                            p_res_overrides:
+                                                *const root::spirv_cross::MSLResourceBinding,
+                                            res_override_count: usize)
          -> root::ScInternalResult;
     }
     extern "C" {

--- a/spirv_cross/src/bindings.rs
+++ b/spirv_cross/src/bindings.rs
@@ -8,7 +8,7 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         pub type Id = ::std::os::raw::c_uint;
-        #[repr(u32)]
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum SourceLanguage {
             SourceLanguageUnknown = 0,
@@ -19,7 +19,7 @@ pub mod root {
             SourceLanguageHLSL = 5,
             SourceLanguageMax = 2147483647,
         }
-        #[repr(u32)]
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum ExecutionModel {
             ExecutionModelVertex = 0,
@@ -31,7 +31,7 @@ pub mod root {
             ExecutionModelKernel = 6,
             ExecutionModelMax = 2147483647,
         }
-        #[repr(u32)]
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum AddressingModel {
             AddressingModelLogical = 0,
@@ -39,7 +39,7 @@ pub mod root {
             AddressingModelPhysical64 = 2,
             AddressingModelMax = 2147483647,
         }
-        #[repr(u32)]
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum MemoryModel {
             MemoryModelSimple = 0,
@@ -47,7 +47,7 @@ pub mod root {
             MemoryModelOpenCL = 2,
             MemoryModelMax = 2147483647,
         }
-        #[repr(u32)]
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum ExecutionMode {
             ExecutionModeInvocations = 0,
@@ -83,7 +83,7 @@ pub mod root {
             ExecutionModeContractionOff = 31,
             ExecutionModeMax = 2147483647,
         }
-        #[repr(u32)]
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum StorageClass {
             StorageClassUniformConstant = 0,
@@ -101,7 +101,7 @@ pub mod root {
             StorageClassStorageBuffer = 12,
             StorageClassMax = 2147483647,
         }
-        #[repr(u32)]
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum Dim {
             Dim1D = 0,
@@ -113,7 +113,7 @@ pub mod root {
             DimSubpassData = 6,
             DimMax = 2147483647,
         }
-        #[repr(u32)]
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum SamplerAddressingMode {
             SamplerAddressingModeNone = 0,
@@ -123,14 +123,14 @@ pub mod root {
             SamplerAddressingModeRepeatMirrored = 4,
             SamplerAddressingModeMax = 2147483647,
         }
-        #[repr(u32)]
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum SamplerFilterMode {
             SamplerFilterModeNearest = 0,
             SamplerFilterModeLinear = 1,
             SamplerFilterModeMax = 2147483647,
         }
-        #[repr(u32)]
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum ImageFormat {
             ImageFormatUnknown = 0,
@@ -175,7 +175,7 @@ pub mod root {
             ImageFormatR8ui = 39,
             ImageFormatMax = 2147483647,
         }
-        #[repr(u32)]
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum ImageChannelOrder {
             ImageChannelOrderR = 0,
@@ -200,7 +200,7 @@ pub mod root {
             ImageChannelOrderABGR = 19,
             ImageChannelOrderMax = 2147483647,
         }
-        #[repr(u32)]
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum ImageChannelDataType {
             ImageChannelDataTypeSnormInt8 = 0,
@@ -222,7 +222,7 @@ pub mod root {
             ImageChannelDataTypeUnormInt101010_2 = 16,
             ImageChannelDataTypeMax = 2147483647,
         }
-        #[repr(u32)]
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum ImageOperandsShift {
             ImageOperandsBiasShift = 0,
@@ -298,8 +298,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct ImageOperandsMask(pub ::std::os::raw::c_uint);
-        #[repr(u32)]
+        pub struct ImageOperandsMask(pub ::std::os::raw::c_int);
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum FPFastMathModeShift {
             FPFastMathModeNotNaNShift = 0,
@@ -363,8 +363,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct FPFastMathModeMask(pub ::std::os::raw::c_uint);
-        #[repr(u32)]
+        pub struct FPFastMathModeMask(pub ::std::os::raw::c_int);
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum FPRoundingMode {
             FPRoundingModeRTE = 0,
@@ -373,14 +373,14 @@ pub mod root {
             FPRoundingModeRTN = 3,
             FPRoundingModeMax = 2147483647,
         }
-        #[repr(u32)]
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum LinkageType {
             LinkageTypeExport = 0,
             LinkageTypeImport = 1,
             LinkageTypeMax = 2147483647,
         }
-        #[repr(u32)]
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum AccessQualifier {
             AccessQualifierReadOnly = 0,
@@ -388,7 +388,7 @@ pub mod root {
             AccessQualifierReadWrite = 2,
             AccessQualifierMax = 2147483647,
         }
-        #[repr(u32)]
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum FunctionParameterAttribute {
             FunctionParameterAttributeZext = 0,
@@ -401,7 +401,7 @@ pub mod root {
             FunctionParameterAttributeNoReadWrite = 7,
             FunctionParameterAttributeMax = 2147483647,
         }
-        #[repr(u32)]
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum Decoration {
             DecorationRelaxedPrecision = 0,
@@ -453,7 +453,7 @@ pub mod root {
             DecorationSecondaryViewportRelativeNV = 5256,
             DecorationMax = 2147483647,
         }
-        #[repr(u32)]
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum BuiltIn {
             BuiltInPosition = 0,
@@ -514,7 +514,7 @@ pub mod root {
             BuiltInViewportMaskPerViewNV = 5262,
             BuiltInMax = 2147483647,
         }
-        #[repr(u32)]
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum SelectionControlShift {
             SelectionControlFlattenShift = 0,
@@ -567,8 +567,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct SelectionControlMask(pub ::std::os::raw::c_uint);
-        #[repr(u32)]
+        pub struct SelectionControlMask(pub ::std::os::raw::c_int);
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum LoopControlShift {
             LoopControlUnrollShift = 0,
@@ -620,8 +620,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct LoopControlMask(pub ::std::os::raw::c_uint);
-        #[repr(u32)]
+        pub struct LoopControlMask(pub ::std::os::raw::c_int);
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum FunctionControlShift {
             FunctionControlInlineShift = 0,
@@ -681,8 +681,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct FunctionControlMask(pub ::std::os::raw::c_uint);
-        #[repr(u32)]
+        pub struct FunctionControlMask(pub ::std::os::raw::c_int);
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum MemorySemanticsShift {
             MemorySemanticsAcquireShift = 1,
@@ -766,8 +766,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct MemorySemanticsMask(pub ::std::os::raw::c_uint);
-        #[repr(u32)]
+        pub struct MemorySemanticsMask(pub ::std::os::raw::c_int);
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum MemoryAccessShift {
             MemoryAccessVolatileShift = 0,
@@ -823,8 +823,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct MemoryAccessMask(pub ::std::os::raw::c_uint);
-        #[repr(u32)]
+        pub struct MemoryAccessMask(pub ::std::os::raw::c_int);
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum Scope {
             ScopeCrossDevice = 0,
@@ -834,7 +834,7 @@ pub mod root {
             ScopeInvocation = 4,
             ScopeMax = 2147483647,
         }
-        #[repr(u32)]
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum GroupOperation {
             GroupOperationReduce = 0,
@@ -890,8 +890,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct KernelEnqueueFlags(pub ::std::os::raw::c_uint);
-        #[repr(u32)]
+        pub struct KernelEnqueueFlags(pub ::std::os::raw::c_int);
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum KernelProfilingInfoShift {
             KernelProfilingInfoCmdExecTimeShift = 0,
@@ -941,14 +941,14 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct KernelProfilingInfoMask(pub ::std::os::raw::c_uint);
+        pub struct KernelProfilingInfoMask(pub ::std::os::raw::c_int);
         pub const Capability_CapabilityStorageUniformBufferBlock16:
                   root::spv::Capability =
             Capability::CapabilityStorageBuffer16BitAccess;
         pub const Capability_CapabilityUniformAndStorageBuffer16BitAccess:
                   root::spv::Capability =
             Capability::CapabilityStorageUniform16;
-        #[repr(u32)]
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum Capability {
             CapabilityMatrix = 0,
@@ -1026,7 +1026,7 @@ pub mod root {
             CapabilityPerViewAttributesNV = 5260,
             CapabilityMax = 2147483647,
         }
-        #[repr(u32)]
+        #[repr(i32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum Op {
             OpNop = 0,
@@ -1335,9 +1335,12 @@ pub mod root {
     pub mod std {
         #[allow(unused_imports)]
         use self::super::super::root;
-        pub type string = [u64; 3usize];
+        pub mod tr1 {
+            #[allow(unused_imports)]
+            use self::super::super::super::root;
+        }
+        pub type string = [u64; 4usize];
     }
-    pub type __darwin_size_t = ::std::os::raw::c_ulong;
     pub mod spirv_cross {
         #[allow(unused_imports)]
         use self::super::super::root;
@@ -1351,7 +1354,7 @@ pub mod root {
         }
         #[test]
         fn bindgen_test_layout_Resource() {
-            assert_eq!(::std::mem::size_of::<Resource>() , 40usize , concat !
+            assert_eq!(::std::mem::size_of::<Resource>() , 48usize , concat !
                        ( "Size of: " , stringify ! ( Resource ) ));
             assert_eq! (::std::mem::align_of::<Resource>() , 8usize , concat !
                         ( "Alignment of " , stringify ! ( Resource ) ));
@@ -1506,7 +1509,7 @@ pub mod root {
     pub type ScInternalCompilerBase = ::std::os::raw::c_void;
     pub type ScInternalCompilerHlsl = ::std::os::raw::c_void;
     pub type ScInternalCompilerMsl = ::std::os::raw::c_void;
-    #[repr(u32)]
+    #[repr(i32)]
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
     pub enum ScInternalResult {
         Success = 0,
@@ -1806,13 +1809,7 @@ pub mod root {
     extern "C" {
         pub fn sc_internal_compiler_msl_new(compiler:
                                                 *mut *mut root::ScInternalCompilerMsl,
-                                            ir: *const u32, size: usize,
-                                            p_vat_overrides:
-                                                *const root::spirv_cross::MSLVertexAttr,
-                                            vat_override_count: usize,
-                                            p_res_overrides:
-                                                *const root::spirv_cross::MSLResourceBinding,
-                                            res_override_count: usize)
+                                            ir: *const u32, size: usize)
          -> root::ScInternalResult;
     }
     extern "C" {
@@ -1820,6 +1817,19 @@ pub mod root {
                                                         *const root::ScInternalCompilerHlsl,
                                                     options:
                                                         *const root::ScMslCompilerOptions)
+         -> root::ScInternalResult;
+    }
+    extern "C" {
+        pub fn sc_internal_compiler_msl_compile(compiler:
+                                                    *const root::ScInternalCompilerBase,
+                                                shader:
+                                                    *mut *const ::std::os::raw::c_char,
+                                                p_vat_overrides:
+                                                    *const root::spirv_cross::MSLVertexAttr,
+                                                vat_override_count: usize,
+                                                p_res_overrides:
+                                                    *const root::spirv_cross::MSLResourceBinding,
+                                                res_override_count: usize)
          -> root::ScInternalResult;
     }
     extern "C" {

--- a/spirv_cross/src/compiler.rs
+++ b/spirv_cross/src/compiler.rs
@@ -9,17 +9,32 @@ use std::{mem, ptr, slice};
 use std::ffi::CStr;
 
 impl spirv::ExecutionModel {
-    fn from_raw(raw: spv::ExecutionModel) -> Result<spirv::ExecutionModel, ErrorCode> {
+    fn from_raw(raw: spv::ExecutionModel) -> Result<Self, ErrorCode> {
         use spirv::ExecutionModel::*;
+        use self::spv::ExecutionModel as Em;
         match raw {
-            spv::ExecutionModel::ExecutionModelVertex => Ok(Vertex),
-            spv::ExecutionModel::ExecutionModelTessellationControl => Ok(TessellationControl),
-            spv::ExecutionModel::ExecutionModelTessellationEvaluation => Ok(TessellationEvaluation),
-            spv::ExecutionModel::ExecutionModelGeometry => Ok(Geometry),
-            spv::ExecutionModel::ExecutionModelFragment => Ok(Fragment),
-            spv::ExecutionModel::ExecutionModelGLCompute => Ok(GlCompute),
-            spv::ExecutionModel::ExecutionModelKernel => Ok(Kernel),
+            Em::ExecutionModelVertex => Ok(Vertex),
+            Em::ExecutionModelTessellationControl => Ok(TessellationControl),
+            Em::ExecutionModelTessellationEvaluation => Ok(TessellationEvaluation),
+            Em::ExecutionModelGeometry => Ok(Geometry),
+            Em::ExecutionModelFragment => Ok(Fragment),
+            Em::ExecutionModelGLCompute => Ok(GlCompute),
+            Em::ExecutionModelKernel => Ok(Kernel),
             _ => Err(ErrorCode::Unhandled),
+        }
+    }
+
+    pub(crate) fn as_raw(&self) -> spv::ExecutionModel {
+        use spirv::ExecutionModel::*;
+        use self::spv::ExecutionModel as Em;
+        match *self {
+            Vertex => Em::ExecutionModelVertex,
+            TessellationControl => Em::ExecutionModelTessellationControl,
+            TessellationEvaluation => Em::ExecutionModelTessellationEvaluation,
+            Geometry => Em::ExecutionModelGeometry,
+            Fragment => Em::ExecutionModelFragment,
+            GlCompute => Em::ExecutionModelGLCompute,
+            Kernel => Em::ExecutionModelKernel,
         }
     }
 }

--- a/spirv_cross/src/compiler.rs
+++ b/spirv_cross/src/compiler.rs
@@ -1,4 +1,3 @@
-
 //! Raw compiler bindings for SPIRV-Cross.
 
 use bindings::root::*;
@@ -96,11 +95,12 @@ impl spirv::Decoration {
 }
 
 #[derive(Debug, Clone)]
-pub struct Compiler {
-    pub sc_compiler: *mut ScInternalCompilerBase,
+pub struct Compiler<TTargetData> {
+    pub(crate) sc_compiler: *mut ScInternalCompilerBase,
+    pub(crate) target_data: TTargetData,
 }
 
-impl Compiler {
+impl<TTargetData> Compiler<TTargetData> {
     pub fn compile(&self) -> Result<String, ErrorCode> {
         unsafe {
             let mut shader_ptr = ptr::null();
@@ -261,7 +261,7 @@ impl Compiler {
     }
 }
 
-impl Drop for Compiler {
+impl<TTargetData> Drop for Compiler<TTargetData> {
     fn drop(&mut self) {
         unsafe {
             sc_internal_compiler_delete(self.sc_compiler);

--- a/spirv_cross/src/hlsl.rs
+++ b/spirv_cross/src/hlsl.rs
@@ -7,8 +7,9 @@ use std::marker::PhantomData;
 #[derive(Debug, Clone)]
 pub enum Target {}
 
-#[derive(Debug, Clone, Default)]
-pub struct ParserOptions;
+impl spirv::Target for Target {
+    type Data = ();
+}
 
 /// A HLSL shader model version.
 #[allow(non_snake_case, non_camel_case_types)]
@@ -84,9 +85,7 @@ impl Default for CompilerOptions {
 }
 
 impl spirv::Parse<Target> for spirv::Ast<Target> {
-    type ParserOptions = ParserOptions;
-
-    fn parse(module: &spirv::Module, _options: &ParserOptions) -> Result<Self, ErrorCode> {
+    fn parse(module: &spirv::Module) -> Result<Self, ErrorCode> {
         let compiler = {
             let mut compiler = ptr::null_mut();
             unsafe {
@@ -99,6 +98,7 @@ impl spirv::Parse<Target> for spirv::Ast<Target> {
 
             compiler::Compiler {
                 sc_compiler: compiler,
+                target_data: (),
             }
         };
 
@@ -113,7 +113,7 @@ impl spirv::Compile<Target> for spirv::Ast<Target> {
     type CompilerOptions = CompilerOptions;
 
     /// Set HLSL compiler specific compilation settings.
-    fn set_compile_options(&mut self, options: &CompilerOptions) -> Result<(), ErrorCode> {
+    fn set_compiler_options(&mut self, options: &CompilerOptions) -> Result<(), ErrorCode> {
         let raw_options = options.as_raw();
         unsafe {
             check!(sc_internal_compiler_hlsl_set_options(

--- a/spirv_cross/src/hlsl.rs
+++ b/spirv_cross/src/hlsl.rs
@@ -5,7 +5,10 @@ use std::marker::PhantomData;
 
 /// A HLSL target.
 #[derive(Debug, Clone)]
-pub struct Target;
+pub enum Target {}
+
+#[derive(Debug, Clone, Default)]
+pub struct ParserOptions;
 
 /// A HLSL shader model version.
 #[allow(non_snake_case, non_camel_case_types)]
@@ -81,7 +84,9 @@ impl Default for CompilerOptions {
 }
 
 impl spirv::Parse<Target> for spirv::Ast<Target> {
-    fn parse(module: &spirv::Module) -> Result<Self, ErrorCode> {
+    type ParserOptions = ParserOptions;
+
+    fn parse(module: &spirv::Module, _options: &ParserOptions) -> Result<Self, ErrorCode> {
         let compiler = {
             let mut compiler = ptr::null_mut();
             unsafe {

--- a/spirv_cross/src/msl.rs
+++ b/spirv_cross/src/msl.rs
@@ -1,13 +1,22 @@
 use {compiler, spirv, ErrorCode};
 use bindings::root::*;
 use std::ptr;
-use std::collections::HashMap;
 use std::marker::PhantomData;
+use std::collections::HashMap;
+use std::ffi::CStr;
 
 /// A MSL target.
 #[derive(Debug, Clone)]
 pub enum Target {}
 
+pub struct TargetData {
+    pub(crate) vertex_attribute_overrides: HashMap<VertexAttributeLocation, VertexAttribute>,
+    pub(crate) resource_binding_overrides: HashMap<ResourceBindingLocation, ResourceBinding>,
+}
+
+impl spirv::Target for Target {
+    type Data = TargetData;
+}
 
 /// Location of a vertex attribute to override
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
@@ -38,14 +47,6 @@ pub struct ResourceBinding {
     pub force_used: bool,
 }
 
-/// MSL parser options.
-#[derive(Debug, Clone, Default)]
-pub struct ParserOptions {
-    pub vertex_attribute_overrides: HashMap<VertexAttributeLocation, VertexAttribute>,
-    pub resource_binding_overrides: HashMap<ResourceBindingLocation, ResourceBinding>,
-}
-
-
 #[derive(Debug, Clone)]
 pub struct CompilerVertexOptions {
     pub invert_y: bool,
@@ -61,11 +62,14 @@ impl Default for CompilerVertexOptions {
     }
 }
 
-
 /// MSL compiler options.
 #[derive(Debug, Clone)]
 pub struct CompilerOptions {
     pub vertex: CompilerVertexOptions,
+    /// MSL resource bindings overrides.
+    pub resource_binding_overrides: HashMap<ResourceBindingLocation, ResourceBinding>,
+    /// MSL vertex attribute overrides.
+    pub vertex_attribute_overrides: HashMap<VertexAttributeLocation, VertexAttribute>,
 }
 
 impl CompilerOptions {
@@ -81,59 +85,30 @@ impl Default for CompilerOptions {
     fn default() -> CompilerOptions {
         CompilerOptions {
             vertex: CompilerVertexOptions::default(),
+            resource_binding_overrides: Default::default(),
+            vertex_attribute_overrides: Default::default(),
         }
     }
 }
 
-
-impl spirv::Parse<Target> for spirv::Ast<Target> {
-    type ParserOptions = ParserOptions;
-
-    fn parse(module: &spirv::Module, options: &ParserOptions) -> Result<Self, ErrorCode> {
+impl<'a> spirv::Parse<Target> for spirv::Ast<Target> {
+    fn parse(module: &spirv::Module) -> Result<Self, ErrorCode> {
         let compiler = {
-            let vat_overrides = options.vertex_attribute_overrides
-                .iter()
-                .map(|(loc, vat)| spirv_cross::MSLVertexAttr {
-                    location: loc.0,
-                    msl_buffer: vat.buffer_id,
-                    msl_offset: vat.offset,
-                    msl_stride: vat.stride,
-                    per_instance: match vat.step {
-                        spirv::VertexAttributeStep::Vertex => false,
-                        spirv::VertexAttributeStep::Instance => true,
-                    },
-                    used_by_shader: vat.force_used,
-                })
-                .collect::<Vec<_>>();
-
-            let res_overrides = options.resource_binding_overrides
-                .iter()
-                .map(|(loc, res)| spirv_cross::MSLResourceBinding {
-                    stage: loc.stage.as_raw(),
-                    desc_set: loc.desc_set,
-                    binding: loc.binding,
-                    msl_buffer: res.resource_id,
-                    msl_texture: res.resource_id,
-                    msl_sampler: res.resource_id,
-                    used_by_shader: res.force_used,
-                })
-                .collect::<Vec<_>>();
-
             let mut compiler = ptr::null_mut();
             unsafe {
                 check!(sc_internal_compiler_msl_new(
                     &mut compiler,
                     module.words.as_ptr() as *const u32,
-                    module.words.len() as usize,
-                    vat_overrides.as_ptr(),
-                    vat_overrides.len(),
-                    res_overrides.as_ptr(),
-                    res_overrides.len(),
+                    module.words.len() as usize
                 ));
             }
 
             compiler::Compiler {
                 sc_compiler: compiler,
+                target_data: TargetData {
+                    resource_binding_overrides: Default::default(),
+                    vertex_attribute_overrides: Default::default(),
+                },
             }
         };
 
@@ -148,7 +123,7 @@ impl spirv::Compile<Target> for spirv::Ast<Target> {
     type CompilerOptions = CompilerOptions;
 
     /// Set MSL compiler specific compilation settings.
-    fn set_compile_options(&mut self, options: &CompilerOptions) -> Result<(), ErrorCode> {
+    fn set_compiler_options(&mut self, options: &CompilerOptions) -> Result<(), ErrorCode> {
         let raw_options = options.as_raw();
         unsafe {
             check!(sc_internal_compiler_msl_set_options(
@@ -157,11 +132,75 @@ impl spirv::Compile<Target> for spirv::Ast<Target> {
             ));
         }
 
+        self.compiler.target_data.resource_binding_overrides =
+            options.resource_binding_overrides.clone();
+        self.compiler.target_data.vertex_attribute_overrides =
+            options.vertex_attribute_overrides.clone();
+
         Ok(())
     }
 
     /// Generate MSL shader from the AST.
     fn compile(&self) -> Result<String, ErrorCode> {
-        self.compiler.compile()
+        self.compile_internal()
+    }
+}
+
+impl spirv::Ast<Target> {
+    fn compile_internal(&self) -> Result<String, ErrorCode> {
+        let vat_overrides = self.compiler
+            .target_data
+            .vertex_attribute_overrides
+            .iter()
+            .map(|(loc, vat)| {
+                spirv_cross::MSLVertexAttr {
+                    location: loc.0,
+                    msl_buffer: vat.buffer_id,
+                    msl_offset: vat.offset,
+                    msl_stride: vat.stride,
+                    per_instance: match vat.step {
+                        spirv::VertexAttributeStep::Vertex => false,
+                        spirv::VertexAttributeStep::Instance => true,
+                    },
+                    used_by_shader: vat.force_used,
+                }
+            })
+            .collect::<Vec<_>>();
+
+
+        let res_overrides = self.compiler
+            .target_data
+            .resource_binding_overrides
+            .iter()
+            .map(|(loc, res)| {
+                spirv_cross::MSLResourceBinding {
+                    stage: loc.stage.as_raw(),
+                    desc_set: loc.desc_set,
+                    binding: loc.binding,
+                    msl_buffer: res.resource_id,
+                    msl_texture: res.resource_id,
+                    msl_sampler: res.resource_id,
+                    used_by_shader: res.force_used,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        unsafe {
+            let mut shader_ptr = ptr::null();
+            check!(sc_internal_compiler_msl_compile(
+                self.compiler.sc_compiler,
+                &mut shader_ptr,
+                vat_overrides.as_ptr(),
+                vat_overrides.len(),
+                res_overrides.as_ptr(),
+                res_overrides.len(),
+            ));
+            let shader = match CStr::from_ptr(shader_ptr).to_owned().into_string() {
+                Err(_) => return Err(ErrorCode::Unhandled),
+                Ok(v) => v,
+            };
+            check!(sc_internal_free_pointer(shader_ptr as *mut c_void));
+            Ok(shader)
+        }
     }
 }

--- a/spirv_cross/src/msl.rs
+++ b/spirv_cross/src/msl.rs
@@ -55,6 +55,10 @@ impl spirv::Parse<Target> for spirv::Ast<Target> {
                     &mut compiler,
                     module.words.as_ptr() as *const u32,
                     module.words.len() as usize,
+                    ptr::null(),
+                    0, //TODO
+                    ptr::null(),
+                    0, //TODO
                 ));
             }
 

--- a/spirv_cross/src/msl.rs
+++ b/spirv_cross/src/msl.rs
@@ -1,11 +1,50 @@
 use {compiler, spirv, ErrorCode};
 use bindings::root::*;
 use std::ptr;
+use std::collections::HashMap;
 use std::marker::PhantomData;
 
 /// A MSL target.
 #[derive(Debug, Clone)]
-pub struct Target;
+pub enum Target {}
+
+
+/// Location of a vertex attribute to override
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct VertexAttributeLocation(pub u32);
+
+/// Vertex attribute description for overriding
+#[derive(Debug, Clone)]
+pub struct VertexAttribute {
+    pub buffer_id: u32,
+    pub offset: u32,
+    pub stride: u32,
+    pub step: spirv::VertexAttributeStep,
+    pub force_used: bool,
+}
+
+/// Location of a resource binding to override
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct ResourceBindingLocation {
+    pub stage: spirv::ExecutionModel,
+    pub desc_set: u32,
+    pub binding: u32,
+}
+
+/// Resource binding description for overriding
+#[derive(Debug, Clone)]
+pub struct ResourceBinding {
+    pub resource_id: u32,
+    pub force_used: bool,
+}
+
+/// MSL parser options.
+#[derive(Debug, Clone, Default)]
+pub struct ParserOptions {
+    pub vertex_attribute_overrides: HashMap<VertexAttributeLocation, VertexAttribute>,
+    pub resource_binding_overrides: HashMap<ResourceBindingLocation, ResourceBinding>,
+}
+
 
 #[derive(Debug, Clone)]
 pub struct CompilerVertexOptions {
@@ -21,6 +60,7 @@ impl Default for CompilerVertexOptions {
         }
     }
 }
+
 
 /// MSL compiler options.
 #[derive(Debug, Clone)]
@@ -47,18 +87,48 @@ impl Default for CompilerOptions {
 
 
 impl spirv::Parse<Target> for spirv::Ast<Target> {
-    fn parse(module: &spirv::Module) -> Result<Self, ErrorCode> {
+    type ParserOptions = ParserOptions;
+
+    fn parse(module: &spirv::Module, options: &ParserOptions) -> Result<Self, ErrorCode> {
         let compiler = {
+            let vat_overrides = options.vertex_attribute_overrides
+                .iter()
+                .map(|(loc, vat)| spirv_cross::MSLVertexAttr {
+                    location: loc.0,
+                    msl_buffer: vat.buffer_id,
+                    msl_offset: vat.offset,
+                    msl_stride: vat.stride,
+                    per_instance: match vat.step {
+                        spirv::VertexAttributeStep::Vertex => false,
+                        spirv::VertexAttributeStep::Instance => true,
+                    },
+                    used_by_shader: vat.force_used,
+                })
+                .collect::<Vec<_>>();
+
+            let res_overrides = options.resource_binding_overrides
+                .iter()
+                .map(|(loc, res)| spirv_cross::MSLResourceBinding {
+                    stage: loc.stage.as_raw(),
+                    desc_set: loc.desc_set,
+                    binding: loc.binding,
+                    msl_buffer: res.resource_id,
+                    msl_texture: res.resource_id,
+                    msl_sampler: res.resource_id,
+                    used_by_shader: res.force_used,
+                })
+                .collect::<Vec<_>>();
+
             let mut compiler = ptr::null_mut();
             unsafe {
                 check!(sc_internal_compiler_msl_new(
                     &mut compiler,
                     module.words.as_ptr() as *const u32,
                     module.words.len() as usize,
-                    ptr::null(),
-                    0, //TODO
-                    ptr::null(),
-                    0, //TODO
+                    vat_overrides.as_ptr(),
+                    vat_overrides.len(),
+                    res_overrides.as_ptr(),
+                    res_overrides.len(),
                 ));
             }
 

--- a/spirv_cross/src/wrapper.cpp
+++ b/spirv_cross/src/wrapper.cpp
@@ -60,14 +60,30 @@ ScInternalResult sc_internal_compiler_hlsl_set_options(const ScInternalCompilerH
         } while (0);)
 }
 
-ScInternalResult sc_internal_compiler_msl_new(ScInternalCompilerMsl **compiler, const uint32_t *ir, size_t size,
-                                              const spirv_cross::MSLVertexAttr *p_vat_overrides, size_t vat_override_count,
-                                              const spirv_cross::MSLResourceBinding *p_res_overrides, size_t res_override_count)
+ScInternalResult sc_internal_compiler_msl_new(ScInternalCompilerMsl **compiler, const uint32_t *ir, size_t size)
 {
-    INTERNAL_RESULT(do {
-            *compiler = new spirv_cross::CompilerMSL(ir, size,
-                                                     (spirv_cross::MSLVertexAttr *)p_vat_overrides, vat_override_count,
-                                                     (spirv_cross::MSLResourceBinding *)p_res_overrides, res_override_count);
+    INTERNAL_RESULT(*compiler = new spirv_cross::CompilerMSL(ir, size);)
+}
+
+ScInternalResult sc_internal_compiler_msl_compile(const ScInternalCompilerBase *compiler, const char **shader,
+                                                  const spirv_cross::MSLVertexAttr *p_vat_overrides, size_t vat_override_count,
+                                                  const spirv_cross::MSLResourceBinding *p_res_overrides, size_t res_override_count)
+{
+    INTERNAL_RESULT(
+        do {
+            std::vector<spirv_cross::MSLVertexAttr> vat_overrides;
+            if (p_vat_overrides)
+            {
+                vat_overrides.insert(vat_overrides.end(), &p_vat_overrides[0], &p_vat_overrides[vat_override_count]);
+            }
+
+            std::vector<spirv_cross::MSLResourceBinding> res_overrides;
+            if (p_res_overrides)
+            {
+                res_overrides.insert(res_overrides.end(), &p_res_overrides[0], &p_res_overrides[res_override_count]);
+            }
+
+            *shader = strdup(strdup(((spirv_cross::CompilerMSL *)compiler)->compile(&vat_overrides, &res_overrides).c_str()));
         } while (0);)
 }
 
@@ -169,12 +185,7 @@ ScInternalResult sc_internal_compiler_get_shader_resources(const ScInternalCompi
 
 ScInternalResult sc_internal_compiler_compile(const ScInternalCompilerBase *compiler, const char **shader)
 {
-    INTERNAL_RESULT(
-        do {
-            // Unsafe
-            // Release to FFI
-            *shader = strdup(strdup(((spirv_cross::Compiler *)compiler)->compile().c_str()));
-        } while (0);)
+    INTERNAL_RESULT(*shader = strdup(strdup(((spirv_cross::Compiler *)compiler)->compile().c_str()));)
 }
 
 ScInternalResult sc_internal_compiler_delete(ScInternalCompilerBase *compiler)

--- a/spirv_cross/src/wrapper.cpp
+++ b/spirv_cross/src/wrapper.cpp
@@ -60,9 +60,15 @@ ScInternalResult sc_internal_compiler_hlsl_set_options(const ScInternalCompilerH
         } while (0);)
 }
 
-ScInternalResult sc_internal_compiler_msl_new(ScInternalCompilerMsl **compiler, const uint32_t *ir, size_t size)
+ScInternalResult sc_internal_compiler_msl_new(ScInternalCompilerMsl **compiler, const uint32_t *ir, size_t size,
+                                              const spirv_cross::MSLVertexAttr *p_vat_overrides, size_t vat_override_count,
+                                              const spirv_cross::MSLResourceBinding *p_res_overrides, size_t res_override_count)
 {
-    INTERNAL_RESULT(*compiler = new spirv_cross::CompilerMSL(ir, size);)
+    INTERNAL_RESULT(do {
+            *compiler = new spirv_cross::CompilerMSL(ir, size,
+                                                     (spirv_cross::MSLVertexAttr *)p_vat_overrides, vat_override_count,
+                                                     (spirv_cross::MSLResourceBinding *)p_res_overrides, res_override_count);
+        } while (0);)
 }
 
 ScInternalResult sc_internal_compiler_msl_set_options(const ScInternalCompilerMsl *compiler, const ScMslCompilerOptions *options)
@@ -113,7 +119,6 @@ ScInternalResult sc_internal_compiler_get_entry_points(const ScInternalCompilerB
                 entry_points[i]->work_group_size_x = sc_entry_point.workgroup_size.x;
                 entry_points[i]->work_group_size_y = sc_entry_point.workgroup_size.y;
                 entry_points[i]->work_group_size_z = sc_entry_point.workgroup_size.z;
-                i++;
             }
         } while (0);)
 }

--- a/spirv_cross/src/wrapper.hpp
+++ b/spirv_cross/src/wrapper.hpp
@@ -66,16 +66,16 @@ typedef struct ScShaderResources
     ScResourceArray separate_samplers;
 } ScShaderResources;
 
-
 ScInternalResult sc_internal_get_latest_exception_message(const char **message);
 
 ScInternalResult sc_internal_compiler_hlsl_new(ScInternalCompilerHlsl **compiler, const uint32_t *ir, size_t size);
 ScInternalResult sc_internal_compiler_hlsl_set_options(const ScInternalCompilerHlsl *compiler, const ScHlslCompilerOptions *options);
 
-ScInternalResult sc_internal_compiler_msl_new(ScInternalCompilerMsl **compiler, const uint32_t *ir, size_t size,
-                                              const spirv_cross::MSLVertexAttr *p_vat_overrides, size_t vat_override_count,
-                                              const spirv_cross::MSLResourceBinding *p_res_overrides, size_t res_override_count);
+ScInternalResult sc_internal_compiler_msl_new(ScInternalCompilerMsl **compiler, const uint32_t *ir, size_t size);
 ScInternalResult sc_internal_compiler_msl_set_options(const ScInternalCompilerHlsl *compiler, const ScMslCompilerOptions *options);
+ScInternalResult sc_internal_compiler_msl_compile(const ScInternalCompilerBase *compiler, const char **shader,
+                                                  const spirv_cross::MSLVertexAttr *p_vat_overrides, size_t vat_override_count,
+                                                  const spirv_cross::MSLResourceBinding *p_res_overrides, size_t res_override_count);
 
 ScInternalResult sc_internal_compiler_get_decoration(const ScInternalCompilerBase *compiler, uint32_t *result, uint32_t id, spv::Decoration decoration);
 ScInternalResult sc_internal_compiler_set_decoration(const ScInternalCompilerBase *compiler, uint32_t id, spv::Decoration decoration, uint32_t argument);

--- a/spirv_cross/src/wrapper.hpp
+++ b/spirv_cross/src/wrapper.hpp
@@ -1,5 +1,6 @@
 #include "vendor/SPIRV-Cross/spirv.hpp"
 #include "vendor/SPIRV-Cross/spirv_hlsl.hpp"
+#include "vendor/SPIRV-Cross/spirv_msl.hpp"
 
 typedef void ScInternalCompilerBase;
 typedef void ScInternalCompilerHlsl;
@@ -65,12 +66,15 @@ typedef struct ScShaderResources
     ScResourceArray separate_samplers;
 } ScShaderResources;
 
+
 ScInternalResult sc_internal_get_latest_exception_message(const char **message);
 
 ScInternalResult sc_internal_compiler_hlsl_new(ScInternalCompilerHlsl **compiler, const uint32_t *ir, size_t size);
 ScInternalResult sc_internal_compiler_hlsl_set_options(const ScInternalCompilerHlsl *compiler, const ScHlslCompilerOptions *options);
 
-ScInternalResult sc_internal_compiler_msl_new(ScInternalCompilerMsl **compiler, const uint32_t *ir, size_t size);
+ScInternalResult sc_internal_compiler_msl_new(ScInternalCompilerMsl **compiler, const uint32_t *ir, size_t size,
+                                              const spirv_cross::MSLVertexAttr *p_vat_overrides, size_t vat_override_count,
+                                              const spirv_cross::MSLResourceBinding *p_res_overrides, size_t res_override_count);
 ScInternalResult sc_internal_compiler_msl_set_options(const ScInternalCompilerHlsl *compiler, const ScMslCompilerOptions *options);
 
 ScInternalResult sc_internal_compiler_get_decoration(const ScInternalCompilerBase *compiler, uint32_t *result, uint32_t id, spv::Decoration decoration);

--- a/spirv_cross/tests/hlsl_tests.rs
+++ b/spirv_cross/tests/hlsl_tests.rs
@@ -14,10 +14,12 @@ fn hlsl_compiler_options_has_default() {
 
 #[test]
 fn ast_compiles_to_hlsl() {
-    let mut ast = spirv::Ast::<hlsl::Target>::parse(&spirv::Module::from_words(
+    let parser_options = hlsl::ParserOptions::default();
+    let module = spirv::Module::from_words(
         words_from_bytes(include_bytes!("shaders/simple.spv")),
-    )).unwrap();
-    ast.set_compile_options(hlsl::CompilerOptions {
+    );
+    let mut ast = spirv::Ast::<hlsl::Target>::parse(&module, &parser_options).unwrap();
+    ast.set_compile_options(&hlsl::CompilerOptions {
         shader_model: hlsl::ShaderModel::V6_0,
         vertex: hlsl::CompilerVertexOptions::default(),
     }).unwrap();
@@ -71,9 +73,12 @@ SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 
 #[test]
 fn ast_compiles_all_shader_models_to_hlsl() {
-    let mut ast = spirv::Ast::<hlsl::Target>::parse(&spirv::Module::from_words(
+    let parser_options = hlsl::ParserOptions::default();
+    let module = spirv::Module::from_words(
         words_from_bytes(include_bytes!("shaders/simple.spv")),
-    )).unwrap();
+    );
+    let mut ast = spirv::Ast::<hlsl::Target>::parse(&module, &parser_options).unwrap();
+
     let shader_models = [
         hlsl::ShaderModel::V3_0,
         hlsl::ShaderModel::V4_0,
@@ -85,9 +90,9 @@ fn ast_compiles_all_shader_models_to_hlsl() {
         hlsl::ShaderModel::V5_1,
         hlsl::ShaderModel::V6_0,
     ];
-    for shader_model in shader_models.iter() {
-        match ast.set_compile_options(hlsl::CompilerOptions {
-            shader_model: *shader_model,
+    for &shader_model in shader_models.iter() {
+        match ast.set_compile_options(&hlsl::CompilerOptions {
+            shader_model,
             vertex: hlsl::CompilerVertexOptions::default(),
         }) {
             Err(_) => panic!("Did not compile"),

--- a/spirv_cross/tests/hlsl_tests.rs
+++ b/spirv_cross/tests/hlsl_tests.rs
@@ -14,12 +14,9 @@ fn hlsl_compiler_options_has_default() {
 
 #[test]
 fn ast_compiles_to_hlsl() {
-    let parser_options = hlsl::ParserOptions::default();
-    let module = spirv::Module::from_words(
-        words_from_bytes(include_bytes!("shaders/simple.spv")),
-    );
-    let mut ast = spirv::Ast::<hlsl::Target>::parse(&module, &parser_options).unwrap();
-    ast.set_compile_options(&hlsl::CompilerOptions {
+    let module = spirv::Module::from_words(words_from_bytes(include_bytes!("shaders/simple.spv")));
+    let mut ast = spirv::Ast::<hlsl::Target>::parse(&module).unwrap();
+    ast.set_compiler_options(&hlsl::CompilerOptions {
         shader_model: hlsl::ShaderModel::V6_0,
         vertex: hlsl::CompilerVertexOptions::default(),
     }).unwrap();
@@ -73,11 +70,8 @@ SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 
 #[test]
 fn ast_compiles_all_shader_models_to_hlsl() {
-    let parser_options = hlsl::ParserOptions::default();
-    let module = spirv::Module::from_words(
-        words_from_bytes(include_bytes!("shaders/simple.spv")),
-    );
-    let mut ast = spirv::Ast::<hlsl::Target>::parse(&module, &parser_options).unwrap();
+    let module = spirv::Module::from_words(words_from_bytes(include_bytes!("shaders/simple.spv")));
+    let mut ast = spirv::Ast::<hlsl::Target>::parse(&module).unwrap();
 
     let shader_models = [
         hlsl::ShaderModel::V3_0,
@@ -91,7 +85,7 @@ fn ast_compiles_all_shader_models_to_hlsl() {
         hlsl::ShaderModel::V6_0,
     ];
     for &shader_model in shader_models.iter() {
-        match ast.set_compile_options(&hlsl::CompilerOptions {
+        match ast.set_compiler_options(&hlsl::CompilerOptions {
             shader_model,
             vertex: hlsl::CompilerVertexOptions::default(),
         }) {

--- a/spirv_cross/tests/msl_tests.rs
+++ b/spirv_cross/tests/msl_tests.rs
@@ -13,10 +13,23 @@ fn msl_compiler_options_has_default() {
 
 #[test]
 fn ast_compiles_to_msl() {
-    let mut ast = spirv::Ast::<msl::Target>::parse(&spirv::Module::from_words(
+    let mut parser_options = msl::ParserOptions::default();
+    parser_options.resource_binding_overrides.insert(
+        msl::ResourceBindingLocation {
+            stage: spirv::ExecutionModel::Vertex,
+            desc_set: 0,
+            binding: 0,
+        },
+        msl::ResourceBinding {
+            resource_id: 5,
+            force_used: false,
+        },
+    );
+    let module = spirv::Module::from_words(
         words_from_bytes(include_bytes!("shaders/simple.spv")),
-    )).unwrap();
-    ast.set_compile_options(msl::CompilerOptions {
+    );
+    let mut ast = spirv::Ast::<msl::Target>::parse(&module, &parser_options).unwrap();
+    ast.set_compile_options(&msl::CompilerOptions {
         vertex: msl::CompilerVertexOptions::default(),
     }).unwrap();
 
@@ -45,7 +58,7 @@ struct main0_out
     float4 gl_Position [[position]];
 };
 
-vertex main0_out main0(main0_in in [[stage_in]], constant uniform_buffer_object& _22 [[buffer(0)]])
+vertex main0_out main0(main0_in in [[stage_in]], constant uniform_buffer_object& _22 [[buffer(5)]])
 {
     main0_out out = {};
     out.v_normal = in.a_normal;

--- a/spirv_cross/tests/msl_tests.rs
+++ b/spirv_cross/tests/msl_tests.rs
@@ -9,12 +9,18 @@ fn msl_compiler_options_has_default() {
     let compiler_options = msl::CompilerOptions::default();
     assert_eq!(compiler_options.vertex.invert_y, false);
     assert_eq!(compiler_options.vertex.transform_clip_space, false);
+    assert!(compiler_options.resource_binding_overrides.is_empty());
+    assert!(compiler_options.vertex_attribute_overrides.is_empty());
 }
 
 #[test]
 fn ast_compiles_to_msl() {
-    let mut parser_options = msl::ParserOptions::default();
-    parser_options.resource_binding_overrides.insert(
+    let module = spirv::Module::from_words(words_from_bytes(include_bytes!("shaders/simple.spv")));
+    let mut ast = spirv::Ast::<msl::Target>::parse(&module).unwrap();
+
+    let mut compiler_options = msl::CompilerOptions::default();
+
+    compiler_options.resource_binding_overrides.insert(
         msl::ResourceBindingLocation {
             stage: spirv::ExecutionModel::Vertex,
             desc_set: 0,
@@ -25,13 +31,8 @@ fn ast_compiles_to_msl() {
             force_used: false,
         },
     );
-    let module = spirv::Module::from_words(
-        words_from_bytes(include_bytes!("shaders/simple.spv")),
-    );
-    let mut ast = spirv::Ast::<msl::Target>::parse(&module, &parser_options).unwrap();
-    ast.set_compile_options(&msl::CompilerOptions {
-        vertex: msl::CompilerVertexOptions::default(),
-    }).unwrap();
+
+    ast.set_compiler_options(&compiler_options).unwrap();
 
     assert_eq!(
         ast.compile().unwrap(),

--- a/spirv_cross/tests/spirv_tests.rs
+++ b/spirv_cross/tests/spirv_tests.rs
@@ -1,14 +1,17 @@
 extern crate spirv_cross;
-use spirv_cross::{hlsl, spirv};
+use spirv_cross::{hlsl as lang, spirv};
 
 mod common;
 use common::words_from_bytes;
 
 #[test]
 fn ast_gets_entry_points() {
-    let entry_points = spirv::Ast::<hlsl::Target>::parse(&spirv::Module::from_words(
+    let parser_options = lang::ParserOptions::default();
+    let module = spirv::Module::from_words(
         words_from_bytes(include_bytes!("shaders/simple.spv")),
-    )).unwrap()
+    );
+    let entry_points = spirv::Ast::<lang::Target>::parse(&module, &parser_options)
+        .unwrap()
         .get_entry_points()
         .unwrap();
 
@@ -18,9 +21,12 @@ fn ast_gets_entry_points() {
 
 #[test]
 fn ast_gets_shader_resources() {
-    let shader_resources = spirv::Ast::<hlsl::Target>::parse(&spirv::Module::from_words(
+    let parser_options = lang::ParserOptions::default();
+    let module = spirv::Module::from_words(
         words_from_bytes(include_bytes!("shaders/simple.spv")),
-    )).unwrap()
+    );
+    let shader_resources = spirv::Ast::<lang::Target>::parse(&module, &parser_options)
+        .unwrap()
         .get_shader_resources()
         .unwrap();
 
@@ -62,9 +68,12 @@ fn ast_gets_shader_resources() {
 
 #[test]
 fn ast_gets_decoration() {
-    let ast = spirv::Ast::<hlsl::Target>::parse(&spirv::Module::from_words(
+    let parser_options = lang::ParserOptions::default();
+    let module = spirv::Module::from_words(
         words_from_bytes(include_bytes!("shaders/simple.spv")),
-    )).unwrap();
+    );
+    let ast = spirv::Ast::<lang::Target>::parse(&module, &parser_options).unwrap();
+
     let stage_inputs = ast.get_shader_resources().unwrap().stage_inputs;
     let decoration = ast.get_decoration(stage_inputs[0].id, spirv::Decoration::DescriptorSet)
         .unwrap();
@@ -73,9 +82,12 @@ fn ast_gets_decoration() {
 
 #[test]
 fn ast_sets_decoration() {
-    let mut ast = spirv::Ast::<hlsl::Target>::parse(&spirv::Module::from_words(
+    let parser_options = lang::ParserOptions::default();
+    let module = spirv::Module::from_words(
         words_from_bytes(include_bytes!("shaders/simple.spv")),
-    )).unwrap();
+    );
+    let mut ast = spirv::Ast::<lang::Target>::parse(&module, &parser_options).unwrap();
+
     let stage_inputs = ast.get_shader_resources().unwrap().stage_inputs;
     let updated_value = 3;
     ast.set_decoration(

--- a/spirv_cross/tests/spirv_tests.rs
+++ b/spirv_cross/tests/spirv_tests.rs
@@ -6,11 +6,8 @@ use common::words_from_bytes;
 
 #[test]
 fn ast_gets_entry_points() {
-    let parser_options = lang::ParserOptions::default();
-    let module = spirv::Module::from_words(
-        words_from_bytes(include_bytes!("shaders/simple.spv")),
-    );
-    let entry_points = spirv::Ast::<lang::Target>::parse(&module, &parser_options)
+    let module = spirv::Module::from_words(words_from_bytes(include_bytes!("shaders/simple.spv")));
+    let entry_points = spirv::Ast::<lang::Target>::parse(&module)
         .unwrap()
         .get_entry_points()
         .unwrap();
@@ -21,11 +18,8 @@ fn ast_gets_entry_points() {
 
 #[test]
 fn ast_gets_shader_resources() {
-    let parser_options = lang::ParserOptions::default();
-    let module = spirv::Module::from_words(
-        words_from_bytes(include_bytes!("shaders/simple.spv")),
-    );
-    let shader_resources = spirv::Ast::<lang::Target>::parse(&module, &parser_options)
+    let module = spirv::Module::from_words(words_from_bytes(include_bytes!("shaders/simple.spv")));
+    let shader_resources = spirv::Ast::<lang::Target>::parse(&module)
         .unwrap()
         .get_shader_resources()
         .unwrap();
@@ -68,11 +62,8 @@ fn ast_gets_shader_resources() {
 
 #[test]
 fn ast_gets_decoration() {
-    let parser_options = lang::ParserOptions::default();
-    let module = spirv::Module::from_words(
-        words_from_bytes(include_bytes!("shaders/simple.spv")),
-    );
-    let ast = spirv::Ast::<lang::Target>::parse(&module, &parser_options).unwrap();
+    let module = spirv::Module::from_words(words_from_bytes(include_bytes!("shaders/simple.spv")));
+    let ast = spirv::Ast::<lang::Target>::parse(&module).unwrap();
 
     let stage_inputs = ast.get_shader_resources().unwrap().stage_inputs;
     let decoration = ast.get_decoration(stage_inputs[0].id, spirv::Decoration::DescriptorSet)
@@ -82,11 +73,8 @@ fn ast_gets_decoration() {
 
 #[test]
 fn ast_sets_decoration() {
-    let parser_options = lang::ParserOptions::default();
-    let module = spirv::Module::from_words(
-        words_from_bytes(include_bytes!("shaders/simple.spv")),
-    );
-    let mut ast = spirv::Ast::<lang::Target>::parse(&module, &parser_options).unwrap();
+    let module = spirv::Module::from_words(words_from_bytes(include_bytes!("shaders/simple.spv")));
+    let mut ast = spirv::Ast::<lang::Target>::parse(&module).unwrap();
 
     let stage_inputs = ast.get_shader_resources().unwrap().stage_inputs;
     let updated_value = 3;


### PR DESCRIPTION
Builds onto #24 to replace `ParserOptions` with methods. This may also fix the CI failures if memory was being freed too early.