### PR TITLE
Add API for changing specialization constants

### DIFF
--- a/spirv_cross/src/bindings.rs
+++ b/spirv_cross/src/bindings.rs
@@ -1835,6 +1835,36 @@ pub mod root {
     impl Clone for ScShaderResources {
         fn clone(&self) -> Self { *self }
     }
+    #[repr(C)]
+    #[derive(Debug, Copy)]
+    pub struct ScSpecializationConstant {
+        pub id: u32,
+        pub constant_id: u32,
+    }
+    #[test]
+    fn bindgen_test_layout_ScSpecializationConstant() {
+        assert_eq!(::std::mem::size_of::<ScSpecializationConstant>() , 8usize
+                   , concat ! (
+                   "Size of: " , stringify ! ( ScSpecializationConstant ) ));
+        assert_eq! (::std::mem::align_of::<ScSpecializationConstant>() ,
+                    4usize , concat ! (
+                    "Alignment of " , stringify ! ( ScSpecializationConstant )
+                    ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const ScSpecializationConstant ) ) . id as
+                    * const _ as usize } , 0usize , concat ! (
+                    "Alignment of field: " , stringify ! (
+                    ScSpecializationConstant ) , "::" , stringify ! ( id ) ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const ScSpecializationConstant ) ) .
+                    constant_id as * const _ as usize } , 4usize , concat ! (
+                    "Alignment of field: " , stringify ! (
+                    ScSpecializationConstant ) , "::" , stringify ! (
+                    constant_id ) ));
+    }
+    impl Clone for ScSpecializationConstant {
+        fn clone(&self) -> Self { *self }
+    }
     extern "C" {
         pub fn sc_internal_get_latest_exception_message(message:
                                                             *mut *const ::std::os::raw::c_char)
@@ -1931,6 +1961,22 @@ pub mod root {
                                                              *const root::ScInternalCompilerBase,
                                                          shader_resources:
                                                              *mut root::ScShaderResources)
+         -> root::ScInternalResult;
+    }
+    extern "C" {
+        pub fn sc_internal_compiler_get_specialization_constants(compiler:
+                                                                     *const root::ScInternalCompilerBase,
+                                                                 constants:
+                                                                     *mut *mut root::ScSpecializationConstant,
+                                                                 size:
+                                                                     *mut usize)
+         -> root::ScInternalResult;
+    }
+    extern "C" {
+        pub fn sc_internal_compiler_set_scalar_constant(compiler:
+                                                            *const root::ScInternalCompilerBase,
+                                                        id: u32,
+                                                        constant: u64)
          -> root::ScInternalResult;
     }
     extern "C" {

--- a/spirv_cross/src/spirv.rs
+++ b/spirv_cross/src/spirv.rs
@@ -97,6 +97,13 @@ pub struct Resource {
     pub name: String,
 }
 
+/// Specialization constant reference.
+#[derive(Debug, Clone)]
+pub struct SpecializationConstant {
+    pub id: u32,
+    pub constant_id: u32,
+}
+
 /// Shader resources.
 #[derive(Debug, Clone)]
 pub struct ShaderResources {
@@ -186,6 +193,18 @@ where
         );
         self.compiler
             .get_cleansed_entry_point_name(entry_point_name)
+    }
+
+    /// Gets all specialization constants.
+    pub fn get_specialization_constants(&self) -> Result<Vec<SpecializationConstant>, ErrorCode> {
+        self.compiler.get_specialization_constants()
+    }
+
+    /// Set reference of a scalar constant to a value, overriding the default.
+    ///
+    /// Can be used to override specialization constants.
+    pub fn set_scalar_constant(&self, id: u32, value: u64) -> Result<(), ErrorCode> {
+        self.compiler.set_scalar_constant(id, value)
     }
 
     /// Gets shader resources.

--- a/spirv_cross/src/wrapper.cpp
+++ b/spirv_cross/src/wrapper.cpp
@@ -208,6 +208,34 @@ ScInternalResult sc_internal_compiler_get_shader_resources(const ScInternalCompi
         } while (0);)
 }
 
+ScInternalResult sc_internal_compiler_get_specialization_constants(const ScInternalCompilerBase *compiler, ScSpecializationConstant **constants, size_t *size)
+{
+    INTERNAL_RESULT(
+        do {
+            auto const sc_constants = ((const spirv_cross::Compiler *)compiler)->get_specialization_constants();
+            auto const sc_size = sc_constants.size();
+
+            *constants = (ScSpecializationConstant *)malloc(sc_size * sizeof(ScSpecializationConstant));
+            *size = sc_size;
+            for (uint32_t i = 0; i < sc_size; i++)
+            {
+                auto const &sc_constant = sc_constants[i];
+                constants[i]->id = sc_constant.id;
+                constants[i]->constant_id = sc_constant.constant_id;
+            }
+
+        } while (0);)
+}
+
+ScInternalResult sc_internal_compiler_set_scalar_constant(const ScInternalCompilerBase *compiler, uint32_t id, uint64_t constant)
+{
+    INTERNAL_RESULT(
+        do {
+            auto& sc_constant = ((spirv_cross::Compiler *)compiler)->get_constant(id);
+            sc_constant.m.c[0].r[0].u64 = constant;
+        } while (0);)
+}
+
 ScInternalResult sc_internal_compiler_compile(const ScInternalCompilerBase *compiler, const char **shader)
 {
     INTERNAL_RESULT(*shader = strdup(((spirv_cross::Compiler *)compiler)->compile().c_str());)

--- a/spirv_cross/src/wrapper.hpp
+++ b/spirv_cross/src/wrapper.hpp
@@ -75,6 +75,12 @@ typedef struct ScShaderResources
     ScResourceArray separate_samplers;
 } ScShaderResources;
 
+typedef struct ScSpecializationConstant
+{
+    uint32_t id;
+    uint32_t constant_id;
+} ScSpecializationConstant;
+
 ScInternalResult sc_internal_get_latest_exception_message(const char **message);
 
 ScInternalResult sc_internal_compiler_hlsl_new(ScInternalCompilerHlsl **compiler, const uint32_t *ir, size_t size);
@@ -94,6 +100,8 @@ ScInternalResult sc_internal_compiler_set_decoration(const ScInternalCompilerBas
 ScInternalResult sc_internal_compiler_get_entry_points(const ScInternalCompilerBase *compiler, ScEntryPoint **entry_points, size_t *size);
 ScInternalResult sc_internal_compiler_get_cleansed_entry_point_name(const ScInternalCompilerBase *compiler, const char *original_entry_point_name, const char **compiled_entry_point_name);
 ScInternalResult sc_internal_compiler_get_shader_resources(const ScInternalCompilerBase *compiler, ScShaderResources *shader_resources);
+ScInternalResult sc_internal_compiler_get_specialization_constants(const ScInternalCompilerBase *compiler, ScSpecializationConstant **constants, size_t *size);
+ScInternalResult sc_internal_compiler_set_scalar_constant(const ScInternalCompilerBase *compiler, uint32_t id, uint64_t constant);
 ScInternalResult sc_internal_compiler_compile(const ScInternalCompilerBase *compiler, const char **shader);
 ScInternalResult sc_internal_compiler_delete(ScInternalCompilerBase *compiler);
 


### PR DESCRIPTION
Particulary tailored towards the needs of gfx-rs. Constant references in spirv-cross are stored a bit awkwardly due to unions and wrapping inside matrix structs, which complicates the API for us, but we only need the scalar constants.