### PR TITLE
GL combined image/samplers

### DIFF
--- a/spirv_cross/Cargo.toml
+++ b/spirv_cross/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirv_cross"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Joshua Groves <josh@joshgroves.com>"]
 description = "Safe wrapper around SPIRV-Cross"
 license = "Apache-2.0"

--- a/spirv_cross/src/bindings.rs
+++ b/spirv_cross/src/bindings.rs
@@ -8,7 +8,7 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         pub type Id = ::std::os::raw::c_uint;
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum SourceLanguage {
             SourceLanguageUnknown = 0,
@@ -19,7 +19,7 @@ pub mod root {
             SourceLanguageHLSL = 5,
             SourceLanguageMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum ExecutionModel {
             ExecutionModelVertex = 0,
@@ -31,7 +31,7 @@ pub mod root {
             ExecutionModelKernel = 6,
             ExecutionModelMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum AddressingModel {
             AddressingModelLogical = 0,
@@ -39,7 +39,7 @@ pub mod root {
             AddressingModelPhysical64 = 2,
             AddressingModelMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum MemoryModel {
             MemoryModelSimple = 0,
@@ -47,7 +47,7 @@ pub mod root {
             MemoryModelOpenCL = 2,
             MemoryModelMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum ExecutionMode {
             ExecutionModeInvocations = 0,
@@ -83,7 +83,7 @@ pub mod root {
             ExecutionModeContractionOff = 31,
             ExecutionModeMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum StorageClass {
             StorageClassUniformConstant = 0,
@@ -101,7 +101,7 @@ pub mod root {
             StorageClassStorageBuffer = 12,
             StorageClassMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum Dim {
             Dim1D = 0,
@@ -113,7 +113,7 @@ pub mod root {
             DimSubpassData = 6,
             DimMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum SamplerAddressingMode {
             SamplerAddressingModeNone = 0,
@@ -123,14 +123,14 @@ pub mod root {
             SamplerAddressingModeRepeatMirrored = 4,
             SamplerAddressingModeMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum SamplerFilterMode {
             SamplerFilterModeNearest = 0,
             SamplerFilterModeLinear = 1,
             SamplerFilterModeMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum ImageFormat {
             ImageFormatUnknown = 0,
@@ -175,7 +175,7 @@ pub mod root {
             ImageFormatR8ui = 39,
             ImageFormatMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum ImageChannelOrder {
             ImageChannelOrderR = 0,
@@ -200,7 +200,7 @@ pub mod root {
             ImageChannelOrderABGR = 19,
             ImageChannelOrderMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum ImageChannelDataType {
             ImageChannelDataTypeSnormInt8 = 0,
@@ -222,7 +222,7 @@ pub mod root {
             ImageChannelDataTypeUnormInt101010_2 = 16,
             ImageChannelDataTypeMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum ImageOperandsShift {
             ImageOperandsBiasShift = 0,
@@ -298,8 +298,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct ImageOperandsMask(pub ::std::os::raw::c_int);
-        #[repr(i32)]
+        pub struct ImageOperandsMask(pub ::std::os::raw::c_uint);
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum FPFastMathModeShift {
             FPFastMathModeNotNaNShift = 0,
@@ -363,8 +363,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct FPFastMathModeMask(pub ::std::os::raw::c_int);
-        #[repr(i32)]
+        pub struct FPFastMathModeMask(pub ::std::os::raw::c_uint);
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum FPRoundingMode {
             FPRoundingModeRTE = 0,
@@ -373,14 +373,14 @@ pub mod root {
             FPRoundingModeRTN = 3,
             FPRoundingModeMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum LinkageType {
             LinkageTypeExport = 0,
             LinkageTypeImport = 1,
             LinkageTypeMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum AccessQualifier {
             AccessQualifierReadOnly = 0,
@@ -388,7 +388,7 @@ pub mod root {
             AccessQualifierReadWrite = 2,
             AccessQualifierMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum FunctionParameterAttribute {
             FunctionParameterAttributeZext = 0,
@@ -401,7 +401,7 @@ pub mod root {
             FunctionParameterAttributeNoReadWrite = 7,
             FunctionParameterAttributeMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum Decoration {
             DecorationRelaxedPrecision = 0,
@@ -453,7 +453,7 @@ pub mod root {
             DecorationSecondaryViewportRelativeNV = 5256,
             DecorationMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum BuiltIn {
             BuiltInPosition = 0,
@@ -514,7 +514,7 @@ pub mod root {
             BuiltInViewportMaskPerViewNV = 5262,
             BuiltInMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum SelectionControlShift {
             SelectionControlFlattenShift = 0,
@@ -567,8 +567,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct SelectionControlMask(pub ::std::os::raw::c_int);
-        #[repr(i32)]
+        pub struct SelectionControlMask(pub ::std::os::raw::c_uint);
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum LoopControlShift {
             LoopControlUnrollShift = 0,
@@ -620,8 +620,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct LoopControlMask(pub ::std::os::raw::c_int);
-        #[repr(i32)]
+        pub struct LoopControlMask(pub ::std::os::raw::c_uint);
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum FunctionControlShift {
             FunctionControlInlineShift = 0,
@@ -681,8 +681,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct FunctionControlMask(pub ::std::os::raw::c_int);
-        #[repr(i32)]
+        pub struct FunctionControlMask(pub ::std::os::raw::c_uint);
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum MemorySemanticsShift {
             MemorySemanticsAcquireShift = 1,
@@ -766,8 +766,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct MemorySemanticsMask(pub ::std::os::raw::c_int);
-        #[repr(i32)]
+        pub struct MemorySemanticsMask(pub ::std::os::raw::c_uint);
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum MemoryAccessShift {
             MemoryAccessVolatileShift = 0,
@@ -823,8 +823,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct MemoryAccessMask(pub ::std::os::raw::c_int);
-        #[repr(i32)]
+        pub struct MemoryAccessMask(pub ::std::os::raw::c_uint);
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum Scope {
             ScopeCrossDevice = 0,
@@ -834,7 +834,7 @@ pub mod root {
             ScopeInvocation = 4,
             ScopeMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum GroupOperation {
             GroupOperationReduce = 0,
@@ -890,8 +890,8 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct KernelEnqueueFlags(pub ::std::os::raw::c_int);
-        #[repr(i32)]
+        pub struct KernelEnqueueFlags(pub ::std::os::raw::c_uint);
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum KernelProfilingInfoShift {
             KernelProfilingInfoCmdExecTimeShift = 0,
@@ -941,14 +941,14 @@ pub mod root {
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-        pub struct KernelProfilingInfoMask(pub ::std::os::raw::c_int);
+        pub struct KernelProfilingInfoMask(pub ::std::os::raw::c_uint);
         pub const Capability_CapabilityStorageUniformBufferBlock16:
                   root::spv::Capability =
             Capability::CapabilityStorageBuffer16BitAccess;
         pub const Capability_CapabilityUniformAndStorageBuffer16BitAccess:
                   root::spv::Capability =
             Capability::CapabilityStorageUniform16;
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum Capability {
             CapabilityMatrix = 0,
@@ -1026,7 +1026,7 @@ pub mod root {
             CapabilityPerViewAttributesNV = 5260,
             CapabilityMax = 2147483647,
         }
-        #[repr(i32)]
+        #[repr(u32)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub enum Op {
             OpNop = 0,
@@ -1329,18 +1329,25 @@ pub mod root {
             OpSubgroupAnyKHR = 4429,
             OpSubgroupAllEqualKHR = 4430,
             OpSubgroupReadInvocationKHR = 4432,
+            OpGroupIAddNonUniformAMD = 5000,
+            OpGroupFAddNonUniformAMD = 5001,
+            OpGroupFMinNonUniformAMD = 5002,
+            OpGroupUMinNonUniformAMD = 5003,
+            OpGroupSMinNonUniformAMD = 5004,
+            OpGroupFMaxNonUniformAMD = 5005,
+            OpGroupUMaxNonUniformAMD = 5006,
+            OpGroupSMaxNonUniformAMD = 5007,
+            OpFragmentMaskFetchAMD = 5011,
+            OpFragmentFetchAMD = 5012,
             OpMax = 2147483647,
         }
     }
     pub mod std {
         #[allow(unused_imports)]
         use self::super::super::root;
-        pub mod tr1 {
-            #[allow(unused_imports)]
-            use self::super::super::super::root;
-        }
-        pub type string = [u64; 4usize];
+        pub type string = [u64; 3usize];
     }
+    pub type __darwin_size_t = ::std::os::raw::c_ulong;
     pub mod spirv_cross {
         #[allow(unused_imports)]
         use self::super::super::root;
@@ -1354,7 +1361,7 @@ pub mod root {
         }
         #[test]
         fn bindgen_test_layout_Resource() {
-            assert_eq!(::std::mem::size_of::<Resource>() , 48usize , concat !
+            assert_eq!(::std::mem::size_of::<Resource>() , 40usize , concat !
                        ( "Size of: " , stringify ! ( Resource ) ));
             assert_eq! (::std::mem::align_of::<Resource>() , 8usize , concat !
                         ( "Alignment of " , stringify ! ( Resource ) ));
@@ -1510,7 +1517,7 @@ pub mod root {
     pub type ScInternalCompilerHlsl = ::std::os::raw::c_void;
     pub type ScInternalCompilerMsl = ::std::os::raw::c_void;
     pub type ScInternalCompilerGlsl = ::std::os::raw::c_void;
-    #[repr(i32)]
+    #[repr(u32)]
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
     pub enum ScInternalResult {
         Success = 0,
@@ -1964,6 +1971,11 @@ pub mod root {
                                                          *const root::ScInternalCompilerGlsl,
                                                      options:
                                                          *const root::ScGlslCompilerOptions)
+         -> root::ScInternalResult;
+    }
+    extern "C" {
+        pub fn sc_internal_compiler_glsl_build_combined_image_samplers(compiler:
+                                                                           *const root::ScInternalCompilerBase)
          -> root::ScInternalResult;
     }
     extern "C" {

--- a/spirv_cross/src/glsl.rs
+++ b/spirv_cross/src/glsl.rs
@@ -135,6 +135,9 @@ impl spirv::Compile<Target> for spirv::Ast<Target> {
 
     /// Generate GLSL shader from the AST.
     fn compile(&mut self) -> Result<String, ErrorCode> {
+        unsafe {
+            check!(sc_internal_compiler_glsl_build_combined_image_samplers(self.compiler.sc_compiler));
+        }
         self.compiler.compile()
     }
 }

--- a/spirv_cross/src/wrapper.cpp
+++ b/spirv_cross/src/wrapper.cpp
@@ -130,6 +130,14 @@ ScInternalResult sc_internal_compiler_glsl_set_options(const ScInternalCompilerG
         } while (0);)
 }
 
+ScInternalResult sc_internal_compiler_glsl_build_combined_image_samplers(const ScInternalCompilerBase *compiler)
+{
+    INTERNAL_RESULT(
+        do {
+            ((spirv_cross::CompilerGLSL *)compiler)->build_combined_image_samplers();
+        } while (0);)
+}
+
 ScInternalResult sc_internal_compiler_get_decoration(const ScInternalCompilerBase *compiler, uint32_t *result, uint32_t id, spv::Decoration decoration)
 {
     INTERNAL_RESULT(*result = ((spirv_cross::Compiler *)compiler)->get_decoration(id, decoration);)

--- a/spirv_cross/src/wrapper.hpp
+++ b/spirv_cross/src/wrapper.hpp
@@ -102,6 +102,7 @@ ScInternalResult sc_internal_compiler_msl_compile(const ScInternalCompilerBase *
 
 ScInternalResult sc_internal_compiler_glsl_new(ScInternalCompilerGlsl **compiler, const uint32_t *ir, size_t size);
 ScInternalResult sc_internal_compiler_glsl_set_options(const ScInternalCompilerGlsl *compiler, const ScGlslCompilerOptions *options);
+ScInternalResult sc_internal_compiler_glsl_build_combined_image_samplers(const ScInternalCompilerBase *compiler);
 
 ScInternalResult sc_internal_compiler_get_decoration(const ScInternalCompilerBase *compiler, uint32_t *result, uint32_t id, spv::Decoration decoration);
 ScInternalResult sc_internal_compiler_set_decoration(const ScInternalCompilerBase *compiler, uint32_t id, spv::Decoration decoration, uint32_t argument);


### PR DESCRIPTION
The GL compiler requires `build_combined_image_samplers` to have been called prior to compilation when any samplers are present. This commit calls it automatically without any special handling at the moment.