### PR TITLE
Separate overrides for resource types

### DIFF
--- a/examples/src/msl/main.rs
+++ b/examples/src/msl/main.rs
@@ -19,7 +19,9 @@ fn main() {
             binding: 0,
         },
         msl::ResourceBinding {
-            resource_id: 5,
+            buffer_id: 5,
+            texture_id: 6,
+            sampler_id: 7,
             force_used: false,
         },
     );

--- a/spirv_cross/Cargo.toml
+++ b/spirv_cross/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirv_cross"
-version = "0.7.4"
+version = "0.8.0"
 authors = ["Joshua Groves <josh@joshgroves.com>"]
 description = "Safe wrapper around SPIRV-Cross"
 license = "MIT/Apache-2.0"

--- a/spirv_cross/src/msl.rs
+++ b/spirv_cross/src/msl.rs
@@ -43,7 +43,9 @@ pub struct ResourceBindingLocation {
 /// Resource binding description for overriding
 #[derive(Debug, Clone)]
 pub struct ResourceBinding {
-    pub resource_id: u32,
+    pub buffer_id: u32,
+    pub texture_id: u32,
+    pub sampler_id: u32,
     pub force_used: bool,
 }
 
@@ -174,9 +176,9 @@ impl spirv::Ast<Target> {
                 stage: loc.stage.as_raw(),
                 desc_set: loc.desc_set,
                 binding: loc.binding,
-                msl_buffer: res.resource_id,
-                msl_texture: res.resource_id,
-                msl_sampler: res.resource_id,
+                msl_buffer: res.buffer_id,
+                msl_texture: res.texture_id,
+                msl_sampler: res.sampler_id,
                 used_by_shader: res.force_used,
             })
             .collect::<Vec<_>>();

--- a/spirv_cross/tests/msl_tests.rs
+++ b/spirv_cross/tests/msl_tests.rs
@@ -27,7 +27,9 @@ fn ast_compiles_to_msl() {
             binding: 0,
         },
         msl::ResourceBinding {
-            resource_id: 5,
+            buffer_id: 5,
+            texture_id: 6,
+            sampler_id: 7,
             force_used: false,
         },
     );


### PR DESCRIPTION
This is required to get the combined image sampler types.
Also, a breaking change.