### PR TITLE
[msl] use BTreeMap for overrides, fix version numbers

### DIFF
--- a/spirv_cross/Cargo.toml
+++ b/spirv_cross/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirv_cross"
-version = "0.9.8"
+version = "0.10.0"
 authors = ["Joshua Groves <josh@joshgroves.com>"]
 description = "Safe wrapper around SPIRV-Cross"
 license = "MIT/Apache-2.0"

--- a/spirv_cross/src/compiler.rs
+++ b/spirv_cross/src/compiler.rs
@@ -276,8 +276,8 @@ impl<TTargetData> Compiler<TTargetData> {
                     execution_model.as_raw(),
                     &mut cleansed_ptr
                 ));
-                let cleansed = match CStr::from_ptr(cleansed_ptr).to_owned().into_string() {
-                    Ok(c) => c,
+                let cleansed = match CStr::from_ptr(cleansed_ptr).to_str() {
+                    Ok(c) => c.to_owned(),
                     _ => return Err(ErrorCode::Unhandled),
                 };
                 check!(sc_internal_free_pointer(cleansed_ptr as *mut c_void));

--- a/spirv_cross/src/spirv.rs
+++ b/spirv_cross/src/spirv.rs
@@ -11,7 +11,7 @@ pub struct CombinedImageSampler {
 }
 
 /// A stage or compute kernel.
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub enum ExecutionModel {
     Vertex,
     TessellationControl,
@@ -89,7 +89,7 @@ pub struct WorkGroupSize {
 }
 
 /// An entry point for a SPIR-V module.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub struct EntryPoint {
     pub name: String,
     pub execution_model: ExecutionModel,


### PR DESCRIPTION
The `BTreeMap` is needed to be able to hash stuff based on compiler options.