### PR TITLE
Fix unsoundness/crash in get_combined_image_samplers

### DIFF
--- a/spirv_cross/src/wrapper.cpp
+++ b/spirv_cross/src/wrapper.cpp
@@ -163,7 +163,7 @@ extern "C"
     {
         INTERNAL_RESULT(
             do {
-                std::vector<spirv_cross::CombinedImageSampler> ret = ((spirv_cross::CompilerGLSL *)compiler)->get_combined_image_samplers();
+                const std::vector<spirv_cross::CombinedImageSampler>& ret = ((spirv_cross::CompilerGLSL *)compiler)->get_combined_image_samplers();
                 *samplers = (const ScCombinedImageSampler *)ret.data();
                 *size = ret.size();
             } while (0);)


### PR DESCRIPTION
The `vector` is copy-constructed, and then a pointer into it is returned, which is read by the Rust side after it has been destructed.

Causes crashes down the line because the CombinedImageSampler id numbers have become garbage (sometimes subtly, sometimes obviously).