### PR TITLE
Rename to `is_rasterization_enabled`

### DIFF
--- a/spirv_cross/src/msl.rs
+++ b/spirv_cross/src/msl.rs
@@ -248,11 +248,11 @@ impl spirv::Ast<Target> {
         }
     }
 
-    pub fn is_rasterization_disabled(&self) -> Result<bool, ErrorCode> {
+    pub fn is_rasterization_enabled(&self) -> Result<bool, ErrorCode> {
         unsafe {
-            let mut value = false;
-            check!(sc_internal_compiler_msl_get_is_rasterization_disabled(self.compiler.sc_compiler, &mut value));
-            Ok(value)
+            let mut is_disabled = false;
+            check!(sc_internal_compiler_msl_get_is_rasterization_disabled(self.compiler.sc_compiler, &mut is_disabled));
+            Ok(!is_disabled)
         }
     }
 }

--- a/spirv_cross/tests/msl_tests.rs
+++ b/spirv_cross/tests/msl_tests.rs
@@ -14,15 +14,15 @@ fn msl_compiler_options_has_default() {
 }
 
 #[test]
-fn is_rasterization_disabled() {
+fn is_rasterization_enabled() {
     let modules = [
-        (false, spirv::Module::from_words(words_from_bytes(include_bytes!("shaders/simple.vert.spv")))),
-        (true, spirv::Module::from_words(words_from_bytes(include_bytes!("shaders/rasterize_disabled.vert.spv")))),
+        (true, spirv::Module::from_words(words_from_bytes(include_bytes!("shaders/simple.vert.spv")))),
+        (false, spirv::Module::from_words(words_from_bytes(include_bytes!("shaders/rasterize_disabled.vert.spv")))),
     ];
     for (expected, module) in &modules {
         let mut ast = spirv::Ast::<msl::Target>::parse(&module).unwrap();
         ast.compile().unwrap();
-        assert_eq!(*expected, ast.is_rasterization_disabled().unwrap());
+        assert_eq!(*expected, ast.is_rasterization_enabled().unwrap());
     }
 }
 


### PR DESCRIPTION
Before publishing 0.11.0, replace `is_rasterization_disabled` with `is_rasterization_enabled` to be consistent with compiler options.