### PR TITLE
Update to latest SPIRV-Cross master

### DIFF
--- a/examples/src/glsl/main.rs
+++ b/examples/src/glsl/main.rs
@@ -1,7 +1,7 @@
-extern crate spirv_cross;
 extern crate examples;
-use spirv_cross::{glsl, spirv};
+extern crate spirv_cross;
 use examples::words_from_bytes;
+use spirv_cross::{glsl, spirv};
 
 fn main() {
     let module = spirv::Module::from_words(words_from_bytes(include_bytes!("../vertex.spv")));
@@ -11,7 +11,8 @@ fn main() {
     ast.set_compiler_options(&glsl::CompilerOptions {
         version: glsl::Version::V4_60,
         vertex: glsl::CompilerVertexOptions::default(),
-    }).unwrap();
+    })
+    .unwrap();
 
     // List all entry points
     for entry_point in &ast.get_entry_points().unwrap() {

--- a/examples/src/hlsl/main.rs
+++ b/examples/src/hlsl/main.rs
@@ -1,7 +1,7 @@
-extern crate spirv_cross;
 extern crate examples;
-use spirv_cross::{hlsl, spirv};
+extern crate spirv_cross;
 use examples::words_from_bytes;
+use spirv_cross::{hlsl, spirv};
 
 fn main() {
     let module = spirv::Module::from_words(words_from_bytes(include_bytes!("../vertex.spv")));
@@ -13,7 +13,8 @@ fn main() {
         point_size_compat: false,
         point_coord_compat: false,
         vertex: hlsl::CompilerVertexOptions::default(),
-    }).unwrap();
+    })
+    .unwrap();
 
     // List all entry points
     for entry_point in &ast.get_entry_points().unwrap() {

--- a/examples/src/msl/main.rs
+++ b/examples/src/msl/main.rs
@@ -1,7 +1,7 @@
 extern crate examples;
 extern crate spirv_cross;
-use spirv_cross::{msl, spirv};
 use examples::words_from_bytes;
+use spirv_cross::{msl, spirv};
 
 fn main() {
     let module = spirv::Module::from_words(words_from_bytes(include_bytes!("../vertex.spv")));

--- a/examples/src/msl/main.rs
+++ b/examples/src/msl/main.rs
@@ -34,6 +34,7 @@ fn main() {
             stride: 3,
             step: spirv::VertexAttributeStep::Instance,
             force_used: true,
+            format: msl::Format::Other,
         },
     );
 

--- a/spirv_cross/Cargo.toml
+++ b/spirv_cross/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirv_cross"
-version = "0.11.2"
+version = "0.12.0"
 authors = ["Joshua Groves <josh@joshgroves.com>"]
 description = "Safe wrapper around SPIRV-Cross"
 license = "MIT/Apache-2.0"

--- a/spirv_cross/build.rs
+++ b/spirv_cross/build.rs
@@ -20,6 +20,8 @@ fn main() {
         .file("src/wrapper.cpp")
         .file("src/vendor/SPIRV-Cross/spirv_cfg.cpp")
         .file("src/vendor/SPIRV-Cross/spirv_cross.cpp")
+        .file("src/vendor/SPIRV-Cross/spirv_cross_parsed_ir.cpp")
+        .file("src/vendor/SPIRV-Cross/spirv_parser.cpp")
         .file("src/vendor/SPIRV-Cross/spirv_cross_util.cpp")
         .file("src/vendor/SPIRV-Cross/spirv_glsl.cpp")
         .file("src/vendor/SPIRV-Cross/spirv_hlsl.cpp")

--- a/spirv_cross/src/bindings.rs
+++ b/spirv_cross/src/bindings.rs
@@ -1481,18 +1481,22 @@ pub mod root {
             Void = 1,
             Boolean = 2,
             Char = 3,
-            Int = 4,
-            UInt = 5,
-            Int64 = 6,
-            UInt64 = 7,
-            AtomicCounter = 8,
-            Half = 9,
-            Float = 10,
-            Double = 11,
-            Struct = 12,
-            Image = 13,
-            SampledImage = 14,
-            Sampler = 15,
+            SByte = 4,
+            UByte = 5,
+            Short = 6,
+            UShort = 7,
+            Int = 8,
+            UInt = 9,
+            Int64 = 10,
+            UInt64 = 11,
+            AtomicCounter = 12,
+            Half = 13,
+            Float = 14,
+            Double = 15,
+            Struct = 16,
+            Image = 17,
+            SampledImage = 18,
+            Sampler = 19,
         }
         #[repr(C)]
         #[derive(Debug, Copy)]
@@ -1505,6 +1509,13 @@ pub mod root {
         impl Clone for Resource {
             fn clone(&self) -> Self { *self }
         }
+        #[repr(u32)]
+        #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+        pub enum MSLVertexFormat {
+            MSL_VERTEX_FORMAT_OTHER = 0,
+            MSL_VERTEX_FORMAT_UINT8 = 1,
+            MSL_VERTEX_FORMAT_UINT16 = 2,
+        }
         #[repr(C)]
         #[derive(Debug, Copy)]
         pub struct MSLVertexAttr {
@@ -1513,6 +1524,7 @@ pub mod root {
             pub msl_offset: u32,
             pub msl_stride: u32,
             pub per_instance: bool,
+            pub format: root::spirv_cross::MSLVertexFormat,
             pub used_by_shader: bool,
         }
         impl Clone for MSLVertexAttr {
@@ -1597,7 +1609,6 @@ pub mod root {
         pub platform: u8,
         pub version: u32,
         pub enable_point_size_builtin: bool,
-        pub resolve_specialized_array_lengths: bool,
         pub disable_rasterization: bool,
     }
     impl Clone for ScMslCompilerOptions {

--- a/spirv_cross/src/compiler.rs
+++ b/spirv_cross/src/compiler.rs
@@ -176,7 +176,7 @@ impl<TTargetData> Compiler<TTargetData> {
                         id,
                         name.as_ptr(),
                     ));
-                },
+                }
                 _ => return Err(ErrorCode::Unhandled),
             }
         }

--- a/spirv_cross/src/compiler.rs
+++ b/spirv_cross/src/compiler.rs
@@ -121,6 +121,10 @@ impl spirv::Type {
             b::Image => Image { array },
             b::SampledImage => SampledImage { array },
             b::Sampler => Sampler { array },
+            b::SByte => SByte { array },
+            b::UByte => UByte { array },
+            b::Short => Short { array },
+            b::UShort => UShort { array },
         }
     }
 }

--- a/spirv_cross/src/msl.rs
+++ b/spirv_cross/src/msl.rs
@@ -32,8 +32,8 @@ pub enum Format {
 
 impl Format {
     fn as_raw(&self) -> spirv_cross::MSLVertexFormat {
-        use self::Format::*;
         use self::spirv_cross::MSLVertexFormat as R;
+        use self::Format::*;
         match self {
             Other => R::MSL_VERTEX_FORMAT_OTHER,
             Uint8 => R::MSL_VERTEX_FORMAT_UINT8,
@@ -202,36 +202,36 @@ impl spirv::Compile<Target> for spirv::Ast<Target> {
         }
 
         self.compiler.target_data.resource_binding_overrides.clear();
-        self.compiler.target_data.resource_binding_overrides.extend(options
-            .resource_binding_overrides
-            .iter()
-            .map(|(loc, res)| spirv_cross::MSLResourceBinding {
-                stage: loc.stage.as_raw(),
-                desc_set: loc.desc_set,
-                binding: loc.binding,
-                msl_buffer: res.buffer_id,
-                msl_texture: res.texture_id,
-                msl_sampler: res.sampler_id,
-                used_by_shader: res.force_used,
-            })
+        self.compiler.target_data.resource_binding_overrides.extend(
+            options.resource_binding_overrides.iter().map(|(loc, res)| {
+                spirv_cross::MSLResourceBinding {
+                    stage: loc.stage.as_raw(),
+                    desc_set: loc.desc_set,
+                    binding: loc.binding,
+                    msl_buffer: res.buffer_id,
+                    msl_texture: res.texture_id,
+                    msl_sampler: res.sampler_id,
+                    used_by_shader: res.force_used,
+                }
+            }),
         );
 
         self.compiler.target_data.vertex_attribute_overrides.clear();
-        self.compiler.target_data.vertex_attribute_overrides.extend(options
-            .vertex_attribute_overrides
-            .iter()
-            .map(|(loc, vat)| spirv_cross::MSLVertexAttr {
-                location: loc.0,
-                msl_buffer: vat.buffer_id,
-                msl_offset: vat.offset,
-                msl_stride: vat.stride,
-                per_instance: match vat.step {
-                    spirv::VertexAttributeStep::Vertex => false,
-                    spirv::VertexAttributeStep::Instance => true,
-                },
-                used_by_shader: vat.force_used,
-                format: vat.format.as_raw(),
-            })
+        self.compiler.target_data.vertex_attribute_overrides.extend(
+            options.vertex_attribute_overrides.iter().map(|(loc, vat)| {
+                spirv_cross::MSLVertexAttr {
+                    location: loc.0,
+                    msl_buffer: vat.buffer_id,
+                    msl_offset: vat.offset,
+                    msl_stride: vat.stride,
+                    per_instance: match vat.step {
+                        spirv::VertexAttributeStep::Vertex => false,
+                        spirv::VertexAttributeStep::Instance => true,
+                    },
+                    used_by_shader: vat.force_used,
+                    format: vat.format.as_raw(),
+                }
+            }),
         );
 
         Ok(())
@@ -269,7 +269,10 @@ impl spirv::Ast<Target> {
     pub fn is_rasterization_enabled(&self) -> Result<bool, ErrorCode> {
         unsafe {
             let mut is_disabled = false;
-            check!(sc_internal_compiler_msl_get_is_rasterization_disabled(self.compiler.sc_compiler, &mut is_disabled));
+            check!(sc_internal_compiler_msl_get_is_rasterization_disabled(
+                self.compiler.sc_compiler,
+                &mut is_disabled
+            ));
             Ok(!is_disabled)
         }
     }

--- a/spirv_cross/src/spirv.rs
+++ b/spirv_cross/src/spirv.rs
@@ -184,6 +184,18 @@ pub enum Type {
     Sampler {
         array: Vec<u32>,
     },
+    SByte {
+        array: Vec<u32>,
+    },
+    UByte {
+        array: Vec<u32>,
+    },
+    Short {
+        array: Vec<u32>,
+    },
+    UShort {
+        array: Vec<u32>,
+    },
 }
 
 /// A SPIR-V shader module.

--- a/spirv_cross/src/spirv.rs
+++ b/spirv_cross/src/spirv.rs
@@ -251,11 +251,7 @@ where
     }
 
     /// Unsets a decoration.
-    pub fn unset_decoration(
-        &mut self,
-        id: u32,
-        decoration: Decoration,
-    ) -> Result<(), ErrorCode> {
+    pub fn unset_decoration(&mut self, id: u32, decoration: Decoration) -> Result<(), ErrorCode> {
         self.compiler.unset_decoration(id, decoration)
     }
 

--- a/spirv_cross/src/wrapper.cpp
+++ b/spirv_cross/src/wrapper.cpp
@@ -127,7 +127,6 @@ extern "C"
                 msl_options.platform = static_cast<spirv_cross::CompilerMSL::Options::Platform>(options->platform);
                 msl_options.msl_version = options->version;
                 msl_options.enable_point_size_builtin = options->enable_point_size_builtin;
-                msl_options.resolve_specialized_array_lengths = options->resolve_specialized_array_lengths;
                 msl_options.disable_rasterization = options->disable_rasterization;
                 compiler_msl->set_msl_options(msl_options);
             } while (0);)

--- a/spirv_cross/src/wrapper.hpp
+++ b/spirv_cross/src/wrapper.hpp
@@ -59,7 +59,6 @@ extern "C"
         uint8_t platform;
         uint32_t version;
         bool enable_point_size_builtin;
-        bool resolve_specialized_array_lengths;
         bool disable_rasterization;
     } ScMslCompilerOptions;
 

--- a/spirv_cross/tests/glsl_tests.rs
+++ b/spirv_cross/tests/glsl_tests.rs
@@ -15,11 +15,13 @@ fn glsl_compiler_options_has_default() {
 fn ast_compiles_to_glsl() {
     let mut ast = spirv::Ast::<glsl::Target>::parse(&spirv::Module::from_words(words_from_bytes(
         include_bytes!("shaders/simple.vert.spv"),
-    ))).unwrap();
+    )))
+    .unwrap();
     ast.set_compiler_options(&glsl::CompilerOptions {
         version: glsl::Version::V4_60,
         vertex: glsl::CompilerVertexOptions::default(),
-    }).unwrap();
+    })
+    .unwrap();
 
     assert_eq!(
         ast.compile().unwrap(),

--- a/spirv_cross/tests/hlsl_tests.rs
+++ b/spirv_cross/tests/hlsl_tests.rs
@@ -24,7 +24,8 @@ fn ast_compiles_to_hlsl() {
         point_size_compat: false,
         point_coord_compat: false,
         vertex: hlsl::CompilerVertexOptions::default(),
-    }).unwrap();
+    })
+    .unwrap();
 
     assert_eq!(
         ast.compile().unwrap(),

--- a/spirv_cross/tests/hlsl_tests.rs
+++ b/spirv_cross/tests/hlsl_tests.rs
@@ -29,11 +29,12 @@ fn ast_compiles_to_hlsl() {
     assert_eq!(
         ast.compile().unwrap(),
         "\
-cbuffer _22
+cbuffer uniform_buffer_object
 {
     row_major float4x4 _22_u_model_view_projection : packoffset(c0);
     float _22_u_scale : packoffset(c4);
 };
+
 
 static float4 gl_Position;
 static float3 v_normal;

--- a/spirv_cross/tests/msl_tests.rs
+++ b/spirv_cross/tests/msl_tests.rs
@@ -16,8 +16,16 @@ fn msl_compiler_options_has_default() {
 #[test]
 fn is_rasterization_enabled() {
     let modules = [
-        (true, spirv::Module::from_words(words_from_bytes(include_bytes!("shaders/simple.vert.spv")))),
-        (false, spirv::Module::from_words(words_from_bytes(include_bytes!("shaders/rasterize_disabled.vert.spv")))),
+        (
+            true,
+            spirv::Module::from_words(words_from_bytes(include_bytes!("shaders/simple.vert.spv"))),
+        ),
+        (
+            false,
+            spirv::Module::from_words(words_from_bytes(include_bytes!(
+                "shaders/rasterize_disabled.vert.spv"
+            ))),
+        ),
     ];
     for (expected, module) in &modules {
         let mut ast = spirv::Ast::<msl::Target>::parse(&module).unwrap();

--- a/spirv_cross/tests/spirv_tests.rs
+++ b/spirv_cross/tests/spirv_tests.rs
@@ -37,22 +37,16 @@ fn ast_gets_shader_resources() {
     assert_eq!(uniform_buffers[0].name, "uniform_buffer_object");
     assert_eq!(shader_resources.storage_buffers.len(), 0);
     assert_eq!(stage_inputs.len(), 2);
-    assert!(
-        stage_inputs
-            .iter()
-            .any(|stage_input| stage_input.name == "a_normal")
-    );
-    assert!(
-        stage_inputs
-            .iter()
-            .any(|stage_input| stage_input.name == "a_position")
-    );
+    assert!(stage_inputs
+        .iter()
+        .any(|stage_input| stage_input.name == "a_normal"));
+    assert!(stage_inputs
+        .iter()
+        .any(|stage_input| stage_input.name == "a_position"));
     assert_eq!(stage_outputs.len(), 1);
-    assert!(
-        stage_outputs
-            .iter()
-            .any(|stage_output| stage_output.name == "v_normal")
-    );
+    assert!(stage_outputs
+        .iter()
+        .any(|stage_output| stage_output.name == "v_normal"));
     assert_eq!(shader_resources.subpass_inputs.len(), 0);
     assert_eq!(shader_resources.storage_images.len(), 0);
     assert_eq!(shader_resources.sampled_images.len(), 0);
@@ -87,7 +81,8 @@ fn ast_sets_decoration() {
         stage_inputs[0].id,
         spirv::Decoration::DescriptorSet,
         updated_value,
-    ).unwrap();
+    )
+    .unwrap();
     assert_eq!(
         ast.get_decoration(stage_inputs[0].id, spirv::Decoration::DescriptorSet)
             .unwrap(),
@@ -199,7 +194,8 @@ fn ast_gets_member_decoration() {
             uniform_buffers[0].base_type_id,
             1,
             spirv::Decoration::Offset
-        ).unwrap(),
+        )
+        .unwrap(),
         64
     );
 }
@@ -219,14 +215,16 @@ fn ast_sets_member_decoration() {
         1,
         spirv::Decoration::Offset,
         new_offset,
-    ).unwrap();
+    )
+    .unwrap();
 
     assert_eq!(
         ast.get_member_decoration(
             uniform_buffers[0].base_type_id,
             1,
             spirv::Decoration::Offset
-        ).unwrap(),
+        )
+        .unwrap(),
         new_offset
     );
 }


### PR DESCRIPTION
- Update submodule to latest SPIRV-Cross commit
- Add types exposed through the updated bindings
- Add format option for MSL vertex attributes