### PR TITLE
Fix wasm32 build on windows and metal

### DIFF
--- a/spirv_cross/src/lib.rs
+++ b/spirv_cross/src/lib.rs
@@ -45,9 +45,9 @@ mod compiler;
 
 #[cfg(feature = "glsl")]
 pub mod glsl;
-#[cfg(feature = "hlsl")]
+#[cfg(all(feature = "hlsl", not(target_arch = "wasm32")))]
 pub mod hlsl;
-#[cfg(feature = "msl")]
+#[cfg(all(feature = "msl", not(target_arch = "wasm32")))]
 pub mod msl;
 
 pub mod spirv;


### PR DESCRIPTION
When another crate disabled on wasm32 still activates
hlsl or msl feature