### PR TITLE
Disable exceptions

### DIFF
--- a/spirv_cross/build.rs
+++ b/spirv_cross/build.rs
@@ -26,6 +26,10 @@ fn main() {
     }
 
     build
+        .flag("-DSPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS")
+        .flag("-DSPIRV_CROSS_WRAPPER_NO_EXCEPTIONS");
+
+    build
         .file("src/wrapper.cpp")
         .file("src/vendor/SPIRV-Cross/spirv_cfg.cpp")
         .file("src/vendor/SPIRV-Cross/spirv_cross.cpp")


### PR DESCRIPTION
See [try log](https://treeherder.mozilla.org/logviewer.html#/jobs?job_id=269699182&repo=try&lineNumber=18469):
> [task 2019-10-03T23:46:17.607Z] 23:46:17     INFO -  [spirv_cross 0.15.0] cargo:warning=src/vendor/SPIRV-Cross/spirv_common.hpp(1308,4): error: cannot use 'throw' with exceptions disabled
[task 2019-10-03T23:46:17.607Z] 23:46:17     INFO -  [spirv_cross 0.15.0] cargo:warning=                        SPIRV_CROSS_THROW("Overwriting a variant with new type.");
[task 2019-10-03T23:46:17.608Z] 23:46:17     INFO -  [spirv_cross 0.15.0] cargo:warning=                        ^
[task 2019-10-03T23:46:17.608Z] 23:46:17     INFO -  [spirv_cross 0.15.0] cargo:warning=src/vendor/SPIRV-Cross/spirv_cross_error_handling.hpp(60,30): note: expanded from macro 'SPIRV_CROSS_THROW'
[task 2019-10-03T23:46:17.608Z] 23:46:17     INFO -  [spirv_cross 0.15.0] cargo:warning=#define SPIRV_CROSS_THROW(x) throw CompilerError(x)
[task 20