### PR TITLE
Add active_buffer_ranges()

### DIFF
--- a/spirv_cross/src/bindings_native.rs
+++ b/spirv_cross/src/bindings_native.rs
@@ -1624,8 +1624,15 @@ pub mod root {
     pub mod std {
         #[allow(unused_imports)]
         use self::super::super::root;
-        pub type string = [u64; 3usize];
+        pub type string = [u64; 4usize];
     }
+    pub mod __gnu_cxx {
+        #[allow(unused_imports)]
+        use self::super::super::root;
+    }
+    pub type __uint8_t = ::std::os::raw::c_uchar;
+    pub type __int32_t = ::std::os::raw::c_int;
+    pub type __uint32_t = ::std::os::raw::c_uint;
     pub mod SPIRV_CROSS_NAMESPACE {
         #[allow(unused_imports)]
         use self::super::super::root;
@@ -1798,6 +1805,16 @@ pub mod root {
         pub work_group_size_z: u32,
     }
     impl Clone for ScEntryPoint {
+        fn clone(&self) -> Self { *self }
+    }
+    #[repr(C)]
+    #[derive(Debug, Copy)]
+    pub struct ScBufferRange {
+        pub index: ::std::os::raw::c_uint,
+        pub offset: usize,
+        pub range: usize,
+    }
+    impl Clone for ScBufferRange {
         fn clone(&self) -> Self { *self }
     }
     #[repr(C)]
@@ -2074,6 +2091,15 @@ pub mod root {
                                                      entry_points:
                                                          *mut *mut root::ScEntryPoint,
                                                      size: *mut usize)
+         -> root::ScInternalResult;
+    }
+    extern "C" {
+        pub fn sc_internal_compiler_get_active_buffer_ranges(compiler:
+                                                                 *const root::ScInternalCompilerBase,
+                                                             id: u32,
+                                                             active_buffer_ranges:
+                                                                 *mut *mut root::ScBufferRange,
+                                                             size: *mut usize)
          -> root::ScInternalResult;
     }
     extern "C" {

--- a/spirv_cross/src/bindings_wasm.rs
+++ b/spirv_cross/src/bindings_wasm.rs
@@ -1624,8 +1624,15 @@ pub mod root {
     pub mod std {
         #[allow(unused_imports)]
         use self::super::super::root;
-        pub type string = [u64; 3usize];
+        pub type string = [u64; 4usize];
     }
+    pub mod __gnu_cxx {
+        #[allow(unused_imports)]
+        use self::super::super::root;
+    }
+    pub type __uint8_t = ::std::os::raw::c_uchar;
+    pub type __int32_t = ::std::os::raw::c_int;
+    pub type __uint32_t = ::std::os::raw::c_uint;
     pub mod SPIRV_CROSS_NAMESPACE {
         #[allow(unused_imports)]
         use self::super::super::root;

--- a/spirv_cross/src/spirv.rs
+++ b/spirv_cross/src/spirv.rs
@@ -290,6 +290,17 @@ pub struct EntryPoint {
     pub work_group_size: WorkGroupSize,
 }
 
+/// Description of struct member's range.
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+pub struct BufferRange {
+    /// Useful for passing to get_member_name() and get_member_decoration(), testing showes.
+    pub index: u32,
+    /// Bytes from start of buffer not beggining of struct, testing showes.
+    pub offset: usize,
+    /// Size of field in bytes.  From https://github.com/KhronosGroup/SPIRV-Cross/issues/1176#issuecomment-542563608
+    pub range: usize,
+}
+
 /// A resource.
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub struct Resource {
@@ -488,6 +499,11 @@ where
                 "`compile` must be called first",
             )))
         }
+    }
+
+    /// Gets active buffer ragnes.  Useful for push constants.
+    pub fn get_active_buffer_ranges(&self, id: u32) -> Result<Vec<BufferRange>, ErrorCode> {
+        self.compiler.get_active_buffer_ranges(id)
     }
 
     /// Gets all specialization constants.

--- a/spirv_cross/src/wrapper.cpp
+++ b/spirv_cross/src/wrapper.cpp
@@ -268,6 +268,26 @@ extern "C"
             } while (0);)
     }
 
+    ScInternalResult sc_internal_compiler_get_active_buffer_ranges(const ScInternalCompilerBase *compiler, uint32_t id, ScBufferRange **active_buffer_ranges, size_t *size)
+    {
+        INTERNAL_RESULT(
+            do {
+                auto const &comp = *((spirv_cross::Compiler *)compiler);
+                auto const &sc_active_buffer_ranges = comp.get_active_buffer_ranges(id);
+                auto const sc_size = sc_active_buffer_ranges.size();
+
+                *active_buffer_ranges = (ScBufferRange *)malloc(sc_size * sizeof(ScBufferRange));
+                *size = sc_size;
+                for (uint32_t i = 0; i < sc_size; i++)
+                {
+                    auto const &sc_active_buffer_range = sc_active_buffer_ranges[i];
+                    active_buffer_ranges[i]->index = sc_active_buffer_range.index;
+                    active_buffer_ranges[i]->offset = sc_active_buffer_range.offset;
+                    active_buffer_ranges[i]->range = sc_active_buffer_range.range;
+                }
+            } while (0);)
+    }
+
     ScInternalResult sc_internal_compiler_get_cleansed_entry_point_name(const ScInternalCompilerBase *compiler, const char *original_entry_point_name, const spv::ExecutionModel execution_model, const char **compiled_entry_point_name)
     {
         INTERNAL_RESULT(

--- a/spirv_cross/src/wrapper.hpp
+++ b/spirv_cross/src/wrapper.hpp
@@ -27,6 +27,13 @@ extern "C"
         uint32_t work_group_size_z;
     } ScEntryPoint;
 
+    typedef struct ScBufferRange
+    {
+        unsigned index;
+        size_t offset;
+        size_t range;
+    } ScBufferRange;
+
     typedef struct ScCombinedImageSampler
     {
         uint32_t combined_id;
@@ -161,6 +168,7 @@ extern "C"
     ScInternalResult sc_internal_compiler_get_name(const ScInternalCompilerBase *compiler, const uint32_t id, const char **name);
     ScInternalResult sc_internal_compiler_set_name(const ScInternalCompilerBase *compiler, const uint32_t id, const char *name);
     ScInternalResult sc_internal_compiler_get_entry_points(const ScInternalCompilerBase *compiler, ScEntryPoint **entry_points, size_t *size);
+    ScInternalResult sc_internal_compiler_get_active_buffer_ranges(const ScInternalCompilerBase *compiler, uint32_t id, ScBufferRange **active_buffer_ranges, size_t *size);
     ScInternalResult sc_internal_compiler_get_cleansed_entry_point_name(const ScInternalCompilerBase *compiler, const char *original_entry_point_name, const spv::ExecutionModel execution_model, const char **compiled_entry_point_name);
     ScInternalResult sc_internal_compiler_get_shader_resources(const ScInternalCompilerBase *compiler, ScShaderResources *shader_resources);
     ScInternalResult sc_internal_compiler_get_specialization_constants(const ScInternalCompilerBase *compiler, ScSpecializationConstant **constants, size_t *size);


### PR DESCRIPTION
https://github.com/grovesNL/spirv_cross/issues/117

Follows get_entry_points() because it also returns a Vec<_>.  Has no error condition, does not fail.