### PR TITLE
Add wasm bindings for buffer_ranges_function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,17 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - clang-5.0
+    - os: linux
+      compiler: clang
+      env:
+        - JOB="linux_wasm"
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-precise
+            - ubuntu-toolchain-r-test
+          packages:
+            - clang-5.0
 notifications:
   webhooks:
     urls:
@@ -64,3 +75,4 @@ script:
   - if [[ $JOB == "macos_clang" ]]; then .travis/macos_clang.sh; fi
   - if [[ $JOB == "linux_gcc" ]]; then .travis/linux_gcc.sh; fi
   - if [[ $JOB == "linux_clang" ]]; then .travis/linux_clang.sh; fi
+  - if [[ $JOB == "linux_wasm" ]]; then .travis/linux_wasm.sh; fi

--- a/.travis/linux_wasm.sh
+++ b/.travis/linux_wasm.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+export CXX=clang++
+
+rustup target add wasm32-unknown-unknown
+(cd examples && cargo build --target=wasm32-unknown-unknown --verbose)

--- a/.travis/linux_wasm.sh
+++ b/.travis/linux_wasm.sh
@@ -2,4 +2,4 @@
 export CXX=clang++
 
 rustup target add wasm32-unknown-unknown
-(cd examples && cargo build --target=wasm32-unknown-unknown --verbose)
+(cd examples && cargo build --target=wasm32-unknown-unknown --verbose --bin glsl)

--- a/spirv_cross/src/bindings_wasm_functions.rs
+++ b/spirv_cross/src/bindings_wasm_functions.rs
@@ -62,6 +62,14 @@ extern "C" {
     fn _sc_internal_compiler_get_entry_points(compiler: u32, entry_points: u32, size: u32) -> u32;
 
     #[wasm_bindgen(js_namespace = sc_internal)]
+    fn _sc_internal_compiler_get_active_buffer_ranges(
+        compiler: u32,
+        id: u32,
+        active_buffer_ranges: u32,
+        size: u32,
+    ) -> u32;
+
+    #[wasm_bindgen(js_namespace = sc_internal)]
     fn _sc_internal_compiler_get_cleansed_entry_point_name(
         compiler: u32,
         original_entry_point_name: u32,
@@ -353,6 +361,35 @@ pub fn sc_internal_compiler_get_entry_points(
 
         module.free(size_ptr);
         module.free(entry_points_ptr_to_ptr);
+
+        result
+    }
+}
+
+pub fn sc_internal_compiler_get_active_buffer_ranges(
+    compiler: *const bindings::ScInternalCompilerBase,
+    id: u32,
+    active_buffer_ranges: *mut *mut bindings::ScBufferRange,
+    size: *mut usize,
+) -> bindings::ScInternalResult {
+    let module = emscripten::get_module();
+    unsafe {
+        let active_buffer_ranges_ptr_to_ptr = module.allocate(U32_SIZE);
+        let size_ptr = module.allocate(U32_SIZE);
+
+        let result = map_internal_result(_sc_internal_compiler_get_active_buffer_ranges(
+            compiler as u32,
+            id,
+            active_buffer_ranges_ptr_to_ptr.as_offset(),
+            size_ptr.as_offset(),
+        ));
+
+        *active_buffer_ranges =
+            module.get_u32(active_buffer_ranges_ptr_to_ptr) as *mut bindings::ScBufferRange;
+        *size = module.get_u32(size_ptr) as usize;
+
+        module.free(size_ptr);
+        module.free(active_buffer_ranges_ptr_to_ptr);
 
         result
     }


### PR DESCRIPTION
I definitely messed up my fork with rebases, but the commits are all the same.

I'm not sure why spirv_cross msl/hlsl aren't working, but it seems someone disabled them in #111, maybe with good reason. So I changed the wasm CI script to only run the glsl example for that target(is that the only dialect that will run via javascript?).