### PR TITLE
Expose 420pack-extension GLSL option

### DIFF
--- a/examples/src/glsl/main.rs
+++ b/examples/src/glsl/main.rs
@@ -10,7 +10,7 @@ fn main() {
     let mut ast = spirv::Ast::<glsl::Target>::parse(&module).unwrap();
     ast.set_compiler_options(&glsl::CompilerOptions {
         version: glsl::Version::V4_60,
-        no_420_pack_extension: false,
+        enable_420_pack_extension: true,
         vertex: glsl::CompilerVertexOptions::default(),
     })
     .unwrap();

--- a/examples/src/glsl/main.rs
+++ b/examples/src/glsl/main.rs
@@ -10,6 +10,7 @@ fn main() {
     let mut ast = spirv::Ast::<glsl::Target>::parse(&module).unwrap();
     ast.set_compiler_options(&glsl::CompilerOptions {
         version: glsl::Version::V4_60,
+        no_420_pack_extension: false,
         vertex: glsl::CompilerVertexOptions::default(),
     })
     .unwrap();

--- a/spirv_cross/src/bindings_native.rs
+++ b/spirv_cross/src/bindings_native.rs
@@ -2265,8 +2265,8 @@ pub mod root {
         pub vertex_transform_clip_space: bool,
         pub vertex_invert_y: bool,
         pub version: u32,
-        pub no_420_pack_extension: bool,
         pub es: bool,
+        pub no_420_pack_extension: bool,
     }
     #[repr(C)]
     #[derive(Debug, Copy, Clone)]

--- a/spirv_cross/src/bindings_native.rs
+++ b/spirv_cross/src/bindings_native.rs
@@ -2265,6 +2265,7 @@ pub mod root {
         pub vertex_transform_clip_space: bool,
         pub vertex_invert_y: bool,
         pub version: u32,
+        pub no_420_pack_extension: bool,
         pub es: bool,
     }
     #[repr(C)]

--- a/spirv_cross/src/bindings_native.rs
+++ b/spirv_cross/src/bindings_native.rs
@@ -2266,7 +2266,7 @@ pub mod root {
         pub vertex_invert_y: bool,
         pub version: u32,
         pub es: bool,
-        pub no_420_pack_extension: bool,
+        pub enable_420_pack_extension: bool,
     }
     #[repr(C)]
     #[derive(Debug, Copy, Clone)]

--- a/spirv_cross/src/bindings_wasm.rs
+++ b/spirv_cross/src/bindings_wasm.rs
@@ -2236,7 +2236,7 @@ pub mod root {
         pub vertex_transform_clip_space: bool,
         pub vertex_invert_y: bool,
         pub version: u32,
-        pub no_420_pack_extension: bool,
+        pub enable_420_pack_extension: bool,
         pub es: bool,
     }
     #[repr(C)]

--- a/spirv_cross/src/bindings_wasm.rs
+++ b/spirv_cross/src/bindings_wasm.rs
@@ -2236,6 +2236,7 @@ pub mod root {
         pub vertex_transform_clip_space: bool,
         pub vertex_invert_y: bool,
         pub version: u32,
+        pub no_420_pack_extension: bool,
         pub es: bool,
     }
     #[repr(C)]

--- a/spirv_cross/src/glsl.rs
+++ b/spirv_cross/src/glsl.rs
@@ -55,7 +55,7 @@ impl Default for CompilerVertexOptions {
 #[derive(Debug, Clone)]
 pub struct CompilerOptions {
     pub version: Version,
-    pub no_420_pack_extension: bool,
+    pub enable_420_pack_extension: bool,
     pub vertex: CompilerVertexOptions,
 }
 
@@ -83,7 +83,7 @@ impl CompilerOptions {
             vertex_invert_y: self.vertex.invert_y,
             vertex_transform_clip_space: self.vertex.transform_clip_space,
             version,
-            no_420_pack_extension: self.no_420_pack_extension,
+            enable_420_pack_extension: self.enable_420_pack_extension,
             es,
         }
     }
@@ -93,7 +93,7 @@ impl Default for CompilerOptions {
     fn default() -> CompilerOptions {
         CompilerOptions {
             version: Version::V4_50,
-            no_420_pack_extension: false,
+            enable_420_pack_extension: true,
             vertex: CompilerVertexOptions::default(),
         }
     }

--- a/spirv_cross/src/glsl.rs
+++ b/spirv_cross/src/glsl.rs
@@ -55,6 +55,7 @@ impl Default for CompilerVertexOptions {
 #[derive(Debug, Clone)]
 pub struct CompilerOptions {
     pub version: Version,
+    pub no_420_pack_extension: bool,
     pub vertex: CompilerVertexOptions,
 }
 
@@ -82,6 +83,7 @@ impl CompilerOptions {
             vertex_invert_y: self.vertex.invert_y,
             vertex_transform_clip_space: self.vertex.transform_clip_space,
             version,
+            no_420_pack_extension: self.no_420_pack_extension,
             es,
         }
     }
@@ -91,6 +93,7 @@ impl Default for CompilerOptions {
     fn default() -> CompilerOptions {
         CompilerOptions {
             version: Version::V4_50,
+            no_420_pack_extension: false,
             vertex: CompilerVertexOptions::default(),
         }
     }

--- a/spirv_cross/src/wrapper.cpp
+++ b/spirv_cross/src/wrapper.cpp
@@ -188,7 +188,7 @@ extern "C"
                 auto glsl_options = compiler_glsl->get_common_options();
                 glsl_options.version = options->version;
                 glsl_options.es = options->es;
-                glsl_options.enable_420pack_extension = !options->no_420_pack_extension;
+                glsl_options.enable_420pack_extension = options->enable_420_pack_extension;
                 glsl_options.vertex.fixup_clipspace = options->vertex_transform_clip_space;
                 glsl_options.vertex.flip_vert_y = options->vertex_invert_y;
                 compiler_glsl->set_common_options(glsl_options);

--- a/spirv_cross/src/wrapper.cpp
+++ b/spirv_cross/src/wrapper.cpp
@@ -188,6 +188,7 @@ extern "C"
                 auto glsl_options = compiler_glsl->get_common_options();
                 glsl_options.version = options->version;
                 glsl_options.es = options->es;
+                glsl_options.enable_420pack_extension = !options->no_420_pack_extension;
                 glsl_options.vertex.fixup_clipspace = options->vertex_transform_clip_space;
                 glsl_options.vertex.flip_vert_y = options->vertex_invert_y;
                 compiler_glsl->set_common_options(glsl_options);

--- a/spirv_cross/src/wrapper.hpp
+++ b/spirv_cross/src/wrapper.hpp
@@ -87,6 +87,7 @@ extern "C"
         bool vertex_invert_y;
         uint32_t version;
         bool es;
+        bool no_420_pack_extension;
     } ScGlslCompilerOptions;
 
     typedef struct ScResource

--- a/spirv_cross/src/wrapper.hpp
+++ b/spirv_cross/src/wrapper.hpp
@@ -87,7 +87,7 @@ extern "C"
         bool vertex_invert_y;
         uint32_t version;
         bool es;
-        bool no_420_pack_extension;
+        bool enable_420_pack_extension;
     } ScGlslCompilerOptions;
 
     typedef struct ScResource

--- a/spirv_cross/tests/glsl_tests.rs
+++ b/spirv_cross/tests/glsl_tests.rs
@@ -18,6 +18,7 @@ fn ast_compiles_to_glsl() {
     .unwrap();
     ast.set_compiler_options(&glsl::CompilerOptions {
         version: glsl::Version::V4_60,
+        no_420_pack_extension: false,
         vertex: glsl::CompilerVertexOptions::default(),
     })
     .unwrap();
@@ -63,6 +64,7 @@ fn ast_compiles_all_versions_to_glsl() {
         if ast
             .set_compiler_options(&glsl::CompilerOptions {
                 version,
+                no_420_pack_extension: false,
                 vertex: glsl::CompilerVertexOptions::default(),
             })
             .is_err()
@@ -80,6 +82,7 @@ fn ast_renames_interface_variables() {
     vert_ast
         .set_compiler_options(&glsl::CompilerOptions {
             version: glsl::Version::V1_00Es,
+            no_420_pack_extension: false,
             vertex: glsl::CompilerVertexOptions::default(),
         })
         .unwrap();
@@ -96,6 +99,7 @@ fn ast_renames_interface_variables() {
     frag_ast
         .set_compiler_options(&glsl::CompilerOptions {
             version: glsl::Version::V1_00Es,
+            no_420_pack_extension: false,
             vertex: glsl::CompilerVertexOptions::default(),
         })
         .unwrap();
@@ -178,6 +182,7 @@ fn ast_can_rename_combined_image_samplers() {
     .unwrap();
     ast.set_compiler_options(&glsl::CompilerOptions {
         version: glsl::Version::V4_10,
+        no_420_pack_extension: false,
         vertex: glsl::CompilerVertexOptions::default(),
     })
     .unwrap();

--- a/spirv_cross/tests/glsl_tests.rs
+++ b/spirv_cross/tests/glsl_tests.rs
@@ -18,7 +18,7 @@ fn ast_compiles_to_glsl() {
     .unwrap();
     ast.set_compiler_options(&glsl::CompilerOptions {
         version: glsl::Version::V4_60,
-        no_420_pack_extension: false,
+        enable_420_pack_extension: true,
         vertex: glsl::CompilerVertexOptions::default(),
     })
     .unwrap();
@@ -64,7 +64,7 @@ fn ast_compiles_all_versions_to_glsl() {
         if ast
             .set_compiler_options(&glsl::CompilerOptions {
                 version,
-                no_420_pack_extension: false,
+                enable_420_pack_extension: true,
                 vertex: glsl::CompilerVertexOptions::default(),
             })
             .is_err()
@@ -82,7 +82,7 @@ fn ast_renames_interface_variables() {
     vert_ast
         .set_compiler_options(&glsl::CompilerOptions {
             version: glsl::Version::V1_00Es,
-            no_420_pack_extension: false,
+            enable_420_pack_extension: true,
             vertex: glsl::CompilerVertexOptions::default(),
         })
         .unwrap();
@@ -99,7 +99,7 @@ fn ast_renames_interface_variables() {
     frag_ast
         .set_compiler_options(&glsl::CompilerOptions {
             version: glsl::Version::V1_00Es,
-            no_420_pack_extension: false,
+            enable_420_pack_extension: true,
             vertex: glsl::CompilerVertexOptions::default(),
         })
         .unwrap();
@@ -182,7 +182,7 @@ fn ast_can_rename_combined_image_samplers() {
     .unwrap();
     ast.set_compiler_options(&glsl::CompilerOptions {
         version: glsl::Version::V4_10,
-        no_420_pack_extension: false,
+        enable_420_pack_extension: true,
         vertex: glsl::CompilerVertexOptions::default(),
     })
     .unwrap();


### PR DESCRIPTION
I just added the GLSL option to remove the version 420 extension in GLSL 410
i'm not comfortable enough with spirv-cross to add other options

I post this as a draft pull request because the ast_renames_interface_variables test doesn't succeed.

`assertion failed: (left == right)`
left: https://pastebin.com/kATJFEST
right: https://pastebin.com/SDuEKS5q

I have no idea why the precision lines gets added. i'm not that used to GLSL, even less to SPIRV-Cross and even less to the codebase of this rust binding. I hope you have an idea why

EDIT: activating the no_420_pack_extension option seems to enable ES for some reason
EDIT: i messed up some option orders. it now is fixed and ready for review