### PR TITLE
Build in parallel

### DIFF
--- a/spirv_cross/Cargo.toml
+++ b/spirv_cross/Cargo.toml
@@ -18,7 +18,7 @@ hlsl = []
 msl = []
 
 [target.'cfg(not(target_arch = "wasm32"))'.build-dependencies]
-cc = "1.0.4"
+cc = { version = "1", features = ["parallel"] }
 
 [target.wasm32-unknown-unknown.dependencies]
 wasm-bindgen = "0.2.33"


### PR DESCRIPTION
This reduces build time on my machine from 60.1 seconds to 25.4 seconds.

This in turn reduces the build time on my project from 104 seconds to 68 seconds.