### PR TITLE
Add missing GLSL compiler option fields/methods

### DIFF
--- a/examples/src/glsl/main.rs
+++ b/examples/src/glsl/main.rs
@@ -10,8 +10,7 @@ fn main() {
     let mut ast = spirv::Ast::<glsl::Target>::parse(&module).unwrap();
     ast.set_compiler_options(&glsl::CompilerOptions {
         version: glsl::Version::V4_60,
-        enable_420_pack_extension: true,
-        vertex: glsl::CompilerVertexOptions::default(),
+        ..glsl::CompilerOptions::default()
     })
     .unwrap();
 

--- a/spirv_cross/src/bindings_native.rs
+++ b/spirv_cross/src/bindings_native.rs
@@ -2482,9 +2482,21 @@ pub mod root {
     pub struct ScGlslCompilerOptions {
         pub vertex_transform_clip_space: bool,
         pub vertex_invert_y: bool,
+        pub vertex_support_nonzero_base_instance: bool,
+        pub fragment_default_float_precision: u8,
+        pub fragment_default_int_precision: u8,
         pub version: u32,
         pub es: bool,
+        pub force_temporary: bool,
+        pub vulkan_semantics: bool,
+        pub separate_shader_objects: bool,
+        pub flatten_multidimensional_arrays: bool,
         pub enable_420_pack_extension: bool,
+        pub emit_push_constant_as_uniform_buffer: bool,
+        pub emit_uniform_buffer_as_plain_uniforms: bool,
+        pub emit_line_directives: bool,
+        pub enable_storage_image_qualifier_deduction: bool,
+        pub force_zero_initialized_variables: bool,
     }
     #[repr(C)]
     #[derive(Debug, Copy, Clone)]

--- a/spirv_cross/src/bindings_native.rs
+++ b/spirv_cross/src/bindings_native.rs
@@ -2633,6 +2633,18 @@ pub mod root {
         ) -> root::ScInternalResult;
     }
     extern "C" {
+        pub fn sc_internal_compiler_glsl_add_header_line(
+            compiler: *const root::ScInternalCompilerBase,
+            str: *const ::std::os::raw::c_char,
+        ) -> root::ScInternalResult;
+    }
+    extern "C" {
+        pub fn sc_internal_compiler_glsl_flatten_buffer_block(
+            compiler: *const root::ScInternalCompilerBase,
+            id: u32,
+        ) -> root::ScInternalResult;
+    }
+    extern "C" {
         pub fn sc_internal_compiler_get_decoration(
             compiler: *const root::ScInternalCompilerBase,
             result: *mut u32,

--- a/spirv_cross/src/bindings_wasm.rs
+++ b/spirv_cross/src/bindings_wasm.rs
@@ -2453,9 +2453,21 @@ pub mod root {
     pub struct ScGlslCompilerOptions {
         pub vertex_transform_clip_space: bool,
         pub vertex_invert_y: bool,
+        pub vertex_support_nonzero_base_instance: bool,
+        pub fragment_default_float_precision: u8,
+        pub fragment_default_int_precision: u8,
         pub version: u32,
         pub es: bool,
+        pub force_temporary: bool,
+        pub vulkan_semantics: bool,
+        pub separate_shader_objects: bool,
+        pub flatten_multidimensional_arrays: bool,
         pub enable_420_pack_extension: bool,
+        pub emit_push_constant_as_uniform_buffer: bool,
+        pub emit_uniform_buffer_as_plain_uniforms: bool,
+        pub emit_line_directives: bool,
+        pub enable_storage_image_qualifier_deduction: bool,
+        pub force_zero_initialized_variables: bool,
     }
     #[repr(C)]
     #[derive(Debug, Copy, Clone)]

--- a/spirv_cross/src/bindings_wasm_functions.rs
+++ b/spirv_cross/src/bindings_wasm_functions.rs
@@ -34,6 +34,18 @@ extern "C" {
     ) -> u32;
 
     #[wasm_bindgen(js_namespace = sc_internal)]
+    fn _sc_internal_compiler_glsl_add_header_line(
+        compiler: u32,
+        str: u32,
+    ) -> u32;
+
+    #[wasm_bindgen(js_namespace = sc_internal)]
+    fn _sc_internal_compiler_glsl_flatten_buffer_block(
+        compiler: u32,
+        id: u32,
+    ) -> u32;
+
+    #[wasm_bindgen(js_namespace = sc_internal)]
     fn _sc_internal_compiler_get_decoration(
         compiler: u32,
         result: u32,
@@ -249,6 +261,38 @@ pub fn sc_internal_compiler_glsl_get_combined_image_samplers(
         module.free(samplers_ptr_to_ptr);
         module.free(size_ptr);
 
+        result
+    }
+}
+
+pub fn sc_internal_compiler_glsl_add_header_line(
+    compiler: *const bindings::ScInternalCompilerBase,
+    str: *const ::std::os::raw::c_char,
+) -> bindings::ScInternalResult {
+    let module = emscripten::get_module();
+    unsafe {
+        let str_bytes = CStr::from_ptr(str).to_bytes();
+        let str_ptr = module.allocate(str_bytes.len() as u32);
+        module.set_from_u8_slice(str_ptr, str_bytes);
+        let result = map_internal_result(_sc_internal_compiler_glsl_add_header_line(
+            compiler as u32,
+            str_ptr.as_offset(),
+        ));
+        module.free(str_ptr);
+        result
+    }
+}
+
+pub fn sc_internal_compiler_glsl_flatten_buffer_block(
+    compiler: *const bindings::ScInternalCompilerBase,
+    id: u32,
+) -> bindings::ScInternalResult {
+    let module = emscripten::get_module();
+    unsafe {
+        let result = map_internal_result(_sc_internal_compiler_glsl_flatten_buffer_block(
+            compiler as u32,
+            id
+        ));
         result
     }
 }

--- a/spirv_cross/src/glsl.rs
+++ b/spirv_cross/src/glsl.rs
@@ -1,6 +1,7 @@
 use crate::bindings as br;
 use crate::ptr_util::read_into_vec_from_ptr;
 use crate::{compiler, spirv, ErrorCode};
+use std::ffi::CString;
 use std::marker::PhantomData;
 use std::ptr;
 
@@ -246,6 +247,34 @@ impl spirv::Ast<Target> {
                 .collect();
 
             Ok(samplers)
+        }
+    }
+
+    pub fn add_header_line(&mut self, line: &str) -> Result<(), ErrorCode> {
+        unsafe {
+            let line = CString::new(line);
+            match line {
+                Ok(line) => {
+                    check!(br::sc_internal_compiler_glsl_add_header_line(
+                        self.compiler.sc_compiler,
+                        line.as_ptr(),
+                    ));
+                }
+                _ => return Err(ErrorCode::Unhandled),
+            }
+
+            Ok(())
+        }
+    }
+
+    pub fn flatten_buffer_block(&mut self, id: u32) -> Result<(), ErrorCode> {
+        unsafe {
+            check!(br::sc_internal_compiler_glsl_flatten_buffer_block(
+                self.compiler.sc_compiler,
+                id,
+            ));
+
+            Ok(())
         }
     }
 }

--- a/spirv_cross/src/glsl.rs
+++ b/spirv_cross/src/glsl.rs
@@ -40,6 +40,7 @@ pub enum Version {
 pub struct CompilerVertexOptions {
     pub invert_y: bool,
     pub transform_clip_space: bool,
+    pub support_nonzero_base_instance: bool,
 }
 
 impl Default for CompilerVertexOptions {
@@ -47,6 +48,31 @@ impl Default for CompilerVertexOptions {
         CompilerVertexOptions {
             invert_y: false,
             transform_clip_space: false,
+            support_nonzero_base_instance: true,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[repr(u8)]
+pub enum Precision {
+    DontCare,
+    Low,
+    Medium,
+    High,
+}
+
+#[derive(Debug, Clone)]
+pub struct CompilerFragmentOptions {
+    pub default_float_precision: Precision,
+    pub default_int_precision: Precision,
+}
+
+impl Default for CompilerFragmentOptions {
+    fn default() -> CompilerFragmentOptions {
+        CompilerFragmentOptions {
+            default_float_precision: Precision::Medium,
+            default_int_precision: Precision::High,
         }
     }
 }
@@ -55,8 +81,18 @@ impl Default for CompilerVertexOptions {
 #[derive(Debug, Clone)]
 pub struct CompilerOptions {
     pub version: Version,
+    pub force_temporary: bool,
+    pub vulkan_semantics: bool,
+    pub separate_shader_objects: bool,
+    pub flatten_multidimensional_arrays: bool,
     pub enable_420_pack_extension: bool,
+    pub emit_push_constant_as_uniform_buffer: bool,
+    pub emit_uniform_buffer_as_plain_uniforms: bool,
+    pub emit_line_directives: bool,
+    pub enable_storage_image_qualifier_deduction: bool,
+    pub force_zero_initialized_variables: bool,
     pub vertex: CompilerVertexOptions,
+    pub fragment: CompilerFragmentOptions,
 }
 
 impl CompilerOptions {
@@ -83,8 +119,20 @@ impl CompilerOptions {
             vertex_invert_y: self.vertex.invert_y,
             vertex_transform_clip_space: self.vertex.transform_clip_space,
             version,
-            enable_420_pack_extension: self.enable_420_pack_extension,
             es,
+            vertex_support_nonzero_base_instance: self.vertex.support_nonzero_base_instance,
+            fragment_default_float_precision: self.fragment.default_float_precision as u8,
+            fragment_default_int_precision: self.fragment.default_int_precision as u8,
+            force_temporary: self.force_temporary,
+            vulkan_semantics: self.vulkan_semantics,
+            separate_shader_objects: self.separate_shader_objects,
+            flatten_multidimensional_arrays: self.flatten_multidimensional_arrays,
+            enable_420_pack_extension: self.enable_420_pack_extension,
+            emit_push_constant_as_uniform_buffer: self.emit_push_constant_as_uniform_buffer,
+            emit_uniform_buffer_as_plain_uniforms: self.emit_uniform_buffer_as_plain_uniforms,
+            emit_line_directives: self.emit_line_directives,
+            enable_storage_image_qualifier_deduction: self.enable_storage_image_qualifier_deduction,
+            force_zero_initialized_variables: self.force_zero_initialized_variables,
         }
     }
 }
@@ -93,8 +141,18 @@ impl Default for CompilerOptions {
     fn default() -> CompilerOptions {
         CompilerOptions {
             version: Version::V4_50,
+            force_temporary: false,
+            vulkan_semantics: false,
+            separate_shader_objects: false,
+            flatten_multidimensional_arrays: false,
             enable_420_pack_extension: true,
+            emit_push_constant_as_uniform_buffer: false,
+            emit_uniform_buffer_as_plain_uniforms: false,
+            emit_line_directives: false,
+            enable_storage_image_qualifier_deduction: true,
+            force_zero_initialized_variables: false,
             vertex: CompilerVertexOptions::default(),
+            fragment: CompilerFragmentOptions::default(),
         }
     }
 }

--- a/spirv_cross/src/glsl.rs
+++ b/spirv_cross/src/glsl.rs
@@ -54,13 +54,14 @@ impl Default for CompilerVertexOptions {
     }
 }
 
+// Note: These values should match with `CompilerGLSL::Options::Precision`.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[repr(u8)]
 pub enum Precision {
-    DontCare,
-    Low,
-    Medium,
-    High,
+    DontCare = 0,
+    Low = 1,
+    Medium = 2,
+    High = 3,
 }
 
 #[derive(Debug, Clone)]

--- a/spirv_cross/src/wrapper.cpp
+++ b/spirv_cross/src/wrapper.cpp
@@ -224,6 +224,22 @@ extern "C"
                 *size = ret.size();
             } while (0);)
     }
+
+    ScInternalResult sc_internal_compiler_glsl_add_header_line(const ScInternalCompilerBase *compiler, const char *str)
+    {
+        INTERNAL_RESULT(
+            do {
+                ((spirv_cross::CompilerGLSL *)compiler)->add_header_line(std::string(str));
+            } while (0);)
+    }
+
+    ScInternalResult sc_internal_compiler_glsl_flatten_buffer_block(const ScInternalCompilerBase *compiler, const uint32_t id)
+    {
+        INTERNAL_RESULT(
+            do {
+                ((spirv_cross::CompilerGLSL *)compiler)->flatten_buffer_block(id);
+            } while (0);)
+    }
 #endif
 
     ScInternalResult sc_internal_compiler_get_decoration(const ScInternalCompilerBase *compiler, uint32_t *result, const uint32_t id, const spv::Decoration decoration)

--- a/spirv_cross/src/wrapper.cpp
+++ b/spirv_cross/src/wrapper.cpp
@@ -188,9 +188,21 @@ extern "C"
                 auto glsl_options = compiler_glsl->get_common_options();
                 glsl_options.version = options->version;
                 glsl_options.es = options->es;
+                glsl_options.force_temporary = options->force_temporary;
+                glsl_options.vulkan_semantics = options->vulkan_semantics;
+                glsl_options.separate_shader_objects = options->separate_shader_objects;
+                glsl_options.flatten_multidimensional_arrays = options->flatten_multidimensional_arrays;
                 glsl_options.enable_420pack_extension = options->enable_420_pack_extension;
+                glsl_options.emit_push_constant_as_uniform_buffer = options->emit_push_constant_as_uniform_buffer;
+                glsl_options.emit_uniform_buffer_as_plain_uniforms = options->emit_uniform_buffer_as_plain_uniforms;
+                glsl_options.emit_line_directives = options->emit_line_directives;
+                glsl_options.enable_storage_image_qualifier_deduction = options->enable_storage_image_qualifier_deduction;
+                glsl_options.force_zero_initialized_variables = options->force_zero_initialized_variables;
                 glsl_options.vertex.fixup_clipspace = options->vertex_transform_clip_space;
                 glsl_options.vertex.flip_vert_y = options->vertex_invert_y;
+                glsl_options.vertex.support_nonzero_base_instance = options->vertex_support_nonzero_base_instance;
+                glsl_options.fragment.default_float_precision = static_cast<spirv_cross::CompilerGLSL::Options::Precision>(options->fragment_default_float_precision);
+                glsl_options.fragment.default_int_precision = static_cast<spirv_cross::CompilerGLSL::Options::Precision>(options->fragment_default_int_precision);
                 compiler_glsl->set_common_options(glsl_options);
             } while (0);)
     }

--- a/spirv_cross/src/wrapper.hpp
+++ b/spirv_cross/src/wrapper.hpp
@@ -177,6 +177,8 @@ extern "C"
     ScInternalResult sc_internal_compiler_glsl_set_options(const ScInternalCompilerGlsl *compiler, const ScGlslCompilerOptions *options);
     ScInternalResult sc_internal_compiler_glsl_build_combined_image_samplers(const ScInternalCompilerBase *compiler);
     ScInternalResult sc_internal_compiler_glsl_get_combined_image_samplers(const ScInternalCompilerBase *compiler, const ScCombinedImageSampler **samplers, size_t *size);
+    ScInternalResult sc_internal_compiler_glsl_add_header_line(const ScInternalCompilerBase *compiler, const char *str);
+    ScInternalResult sc_internal_compiler_glsl_flatten_buffer_block(const ScInternalCompilerBase *compiler, const uint32_t id);
 #endif
 
     ScInternalResult sc_internal_compiler_get_decoration(const ScInternalCompilerBase *compiler, uint32_t *result, const uint32_t id, const spv::Decoration decoration);

--- a/spirv_cross/src/wrapper.hpp
+++ b/spirv_cross/src/wrapper.hpp
@@ -85,9 +85,21 @@ extern "C"
     {
         bool vertex_transform_clip_space;
         bool vertex_invert_y;
+        bool vertex_support_nonzero_base_instance;
+        uint8_t fragment_default_float_precision;
+        uint8_t fragment_default_int_precision;
         uint32_t version;
         bool es;
+        bool force_temporary;
+        bool vulkan_semantics;
+        bool separate_shader_objects;
+        bool flatten_multidimensional_arrays;
         bool enable_420_pack_extension;
+        bool emit_push_constant_as_uniform_buffer;
+        bool emit_uniform_buffer_as_plain_uniforms;
+        bool emit_line_directives;
+        bool enable_storage_image_qualifier_deduction;
+        bool force_zero_initialized_variables;
     } ScGlslCompilerOptions;
 
     typedef struct ScResource

--- a/spirv_cross/tests/glsl_tests.rs
+++ b/spirv_cross/tests/glsl_tests.rs
@@ -233,8 +233,6 @@ fn flatten_uniform_buffers_as_plain_uniforms() {
     })
     .unwrap();
 
-    println!("{}", ast.compile().unwrap());
-
     assert_eq!(
         ast.compile().unwrap(),
         "\
@@ -270,4 +268,39 @@ void main()
     );
 }
 
-// TODO more tests!
+#[test]
+fn low_precision() {
+    let mut ast = spirv::Ast::<glsl::Target>::parse(&spirv::Module::from_words(words_from_bytes(
+        include_bytes!("shaders/sampler.frag.spv"),
+    )))
+    .unwrap();
+    ast.set_compiler_options(&glsl::CompilerOptions {
+        version: glsl::Version::V3_00Es,
+        fragment: glsl::CompilerFragmentOptions {
+            default_float_precision: glsl::Precision::Low,
+            default_int_precision: glsl::Precision::Low,
+        },
+        ..glsl::CompilerOptions::default()
+    })
+    .unwrap();
+
+    assert_eq!(
+        ast.compile().unwrap(),
+        "\
+#version 300 es
+precision lowp float;
+precision lowp int;
+
+uniform highp sampler2D _26;
+
+layout(location = 0) out highp vec4 target0;
+in highp vec2 v_uv;
+
+void main()
+{
+    target0 = texture(_26, v_uv);
+}
+
+"
+    );
+}

--- a/wasm/src/main.rs
+++ b/wasm/src/main.rs
@@ -32,6 +32,8 @@ fn main() {
 		        "_sc_internal_compiler_glsl_set_options",
 		        "_sc_internal_compiler_glsl_build_combined_image_samplers",
 		        "_sc_internal_compiler_glsl_get_combined_image_samplers",
+		        "_sc_internal_compiler_glsl_add_header_line",
+		        "_sc_internal_compiler_glsl_flatten_buffer_block",
 		        "_sc_internal_compiler_get_decoration",
 		        "_sc_internal_compiler_set_decoration",
 		        "_sc_internal_compiler_unset_decoration",


### PR DESCRIPTION
Hi! I noticed that spirv_cross is missing some of the GLSL compiler options in the C++ header. Is this something spirv_cross is interested in?

Some design decisions to note (and nitpick!):
- Add missing fields to `CompilerGLSL::Options`
  - `CompilerGLSL::Options::Precision` is marshalled through `wrapper.{cpp,hpp}` as a `uint8_t`
  - This is a breaking change, as it adds fields to a `pub` struct.
    - I think there's a pattern that can avoid this in the future, involving an unused private field which forces users to do the `..Default::default()`.
- Adds wrapper functions for the `CompilerGLSL` functions: `add_header_line` and `flatten_buffer_block`
  - I did not add all the missing functions, just the ones I need.
- I ran `bindings_generator` on a Windows machine, which changed all the enum representations to `i32`. I'm assuming it was originally generated on macOS (from `__darwin_size_t`), so I didn't commit the non-`ScGlslCompilerOptions` changes.
- I've added a test for the extra field I needed, but I'm happy to add more.
- **I can't get emscripten installed locally, so I cannot re-generate the wasm bindings.**

Thanks for the awesome library!