### PR TITLE
implement std::error::Error for ErrorCode

### DIFF
--- a/spirv_cross/src/lib.rs
+++ b/spirv_cross/src/lib.rs
@@ -85,3 +85,11 @@ pub enum ErrorCode {
     Unhandled,
     CompilationError(String),
 }
+
+impl std::fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for ErrorCode {}


### PR DESCRIPTION
With respect to https://github.com/grovesNL/spirv_cross/issues/49, I think that keeping an error type is the most flexible way to handle errors. This pull request implements Error (and by requirement, Display), to make integrating with other error types easier.