### PR TITLE
Release 0.22.2

### DIFF
--- a/spirv_cross/Cargo.toml
+++ b/spirv_cross/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirv_cross"
-version = "0.22.1"
+version = "0.22.2"
 authors = ["Joshua Groves <josh@joshgroves.com>"]
 description = "Safe wrapper around SPIRV-Cross"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
Technically there are breaking changes in this patch release due to #160, however in practice it seems unlikely that it will cause problems for downstream crates. We'd prefer to release this as a patch release to avoid some dependency churn downstream (especially across gfx/wgpu/wgpu-rs).

If this does turn out to cause problems for other crates downstream, we can always yank this release and bump the minor version instead.