### PR TITLE
Add MSL 2.3 and make versions non-exhaustive

### DIFF
--- a/spirv_cross/src/glsl.rs
+++ b/spirv_cross/src/glsl.rs
@@ -19,6 +19,7 @@ impl spirv::Target for Target {
 
 #[allow(non_snake_case, non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum Version {
     V1_10,
     V1_20,

--- a/spirv_cross/src/hlsl.rs
+++ b/spirv_cross/src/hlsl.rs
@@ -17,6 +17,7 @@ impl spirv::Target for Target {
 /// A HLSL shader model version.
 #[allow(non_snake_case, non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum ShaderModel {
     V3_0,
     V4_0,

--- a/spirv_cross/src/msl.rs
+++ b/spirv_cross/src/msl.rs
@@ -238,6 +238,7 @@ pub enum Platform {
 
 /// A MSL shader model version.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum Version {
     V1_0,
     V1_1,
@@ -245,6 +246,7 @@ pub enum Version {
     V2_0,
     V2_1,
     V2_2,
+    V2_3,
 }
 
 impl Version {
@@ -257,6 +259,7 @@ impl Version {
             V2_0 => 20000,
             V2_1 => 20100,
             V2_2 => 20200,
+            V2_3 => 20300,
         }
     }
 }


### PR DESCRIPTION
Fixes #163

Also added non-exhaustive to versions, which will allow us to avoid breaking changes when we add more variants in the future.