### PR TITLE
Add force_active_argument_buffer_resources to MSL compiler options

### DIFF
--- a/spirv_cross/src/bindings_native.rs
+++ b/spirv_cross/src/bindings_native.rs
@@ -2638,6 +2638,7 @@ pub mod root {
         pub pad_fragment_output_components: bool,
         pub force_native_arrays: bool,
         pub force_zero_initialized_variables: bool,
+        pub force_active_argument_buffer_resources: bool,
     }
     #[repr(C)]
     #[derive(Debug, Copy, Clone)]

--- a/spirv_cross/src/bindings_wasm.rs
+++ b/spirv_cross/src/bindings_wasm.rs
@@ -2600,6 +2600,7 @@ pub mod root {
         pub pad_fragment_output_components: bool,
         pub force_native_arrays: bool,
         pub force_zero_initialized_variables: bool,
+        pub force_active_argument_buffer_resources: bool,
     }
     #[repr(C)]
     #[derive(Debug, Copy, Clone)]

--- a/spirv_cross/src/msl.rs
+++ b/spirv_cross/src/msl.rs
@@ -326,6 +326,8 @@ pub struct CompilerOptions {
     pub force_native_arrays: bool,
     /// Whether to force all uninitialized variables to be initialized to zero.
     pub force_zero_initialized_variables: bool,
+    /// Whether to force always emit resources which are part of argument buffers
+    pub force_active_argument_buffer_resources: bool,
     /// The name and execution model of the entry point to use. If no entry
     /// point is specified, then the first entry point found will be used.
     pub entry_point: Option<(String, spirv::ExecutionModel)>,
@@ -355,6 +357,7 @@ impl Default for CompilerOptions {
             const_samplers: Default::default(),
             force_native_arrays: false,
             force_zero_initialized_variables: false,
+            force_active_argument_buffer_resources: false,
             entry_point: None,
         }
     }
@@ -422,6 +425,7 @@ impl spirv::Compile<Target> for spirv::Ast<Target> {
             pad_fragment_output_components: options.pad_fragment_output_components,
             force_native_arrays: options.force_native_arrays,
             force_zero_initialized_variables: options.force_zero_initialized_variables,
+            force_active_argument_buffer_resources: options.force_active_argument_buffer_resources,
         };
         unsafe {
             check!(br::sc_internal_compiler_msl_set_options(

--- a/spirv_cross/src/wrapper.cpp
+++ b/spirv_cross/src/wrapper.cpp
@@ -167,6 +167,7 @@ extern "C"
                 msl_options.argument_buffers = options->argument_buffers;
                 msl_options.pad_fragment_output_components = options->pad_fragment_output_components;
                 msl_options.force_native_arrays = options->force_native_arrays;
+                msl_options.force_active_argument_buffer_resources = options->force_active_argument_buffer_resources;
                 compiler_msl->set_msl_options(msl_options);
             } while (0);)
     }

--- a/spirv_cross/src/wrapper.hpp
+++ b/spirv_cross/src/wrapper.hpp
@@ -82,6 +82,7 @@ extern "C"
         bool pad_fragment_output_components;
         bool force_native_arrays;
         bool force_zero_initialized_variables;
+        bool force_active_argument_buffer_resources;
     } ScMslCompilerOptions;
 
     typedef struct ScGlslCompilerOptions


### PR DESCRIPTION
This option disables stripping unused fields from argument buffers. This ensures that argument buffers for vertex and fragment functions are identical, allowing the same argument encoder to be used for both. (See https://developer.apple.com/forums/thread/674406)

The binding generation didn't work for me locally (missing clang possibly). However this builds and has the intended effect.