### PR TITLE
reset combined_image_samplers_build flag when entry_point changes

### DIFF
--- a/spirv_cross/src/glsl.rs
+++ b/spirv_cross/src/glsl.rs
@@ -169,6 +169,8 @@ impl spirv::Compile<Target> for spirv::Ast<Target> {
                     model,
                 ));
             }
+
+            self.compiler.target_data.combined_image_samplers_built = false;
         };
 
         use self::Version::*;


### PR DESCRIPTION
Found from https://github.com/gfx-rs/wgpu-rs/issues/723

SPIRV-Cross builds combined image-samplers from entry point, so when it changes they must be rebuild.