### PR TITLE
Fix docs.rs windows build

### DIFF
--- a/spirv_cross/Cargo.toml
+++ b/spirv_cross/Cargo.toml
@@ -23,3 +23,6 @@ cc = { version = "1", features = ["parallel"] }
 [target.wasm32-unknown-unknown.dependencies]
 wasm-bindgen = "0.2.33"
 js-sys = "0.3.10"
+
+[package.metadata.docs.rs]
+features = ["glsl", "hlsl", "msl"]

--- a/spirv_cross/build.rs
+++ b/spirv_cross/build.rs
@@ -1,4 +1,12 @@
 fn main() {
+    // Don't attempt to build SPIRV-Cross native library on docs.rs
+    if std::env::var("DOCS_RS").is_ok() {
+        println!(
+            "cargo:warning=spirv_cross: docs.rs detected, will not attempt to build SPIRV-Cross native library"
+        );
+        return;
+    }
+
     // Prevent building SPIRV-Cross on wasm32 target
     let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH");
     if let Ok(arch) = target_arch {


### PR DESCRIPTION
We can just *not build* SPIRV-Cross when building documentation on docs.rs. 

Fixes #148

Also added all features for docs.rs so they show up on the page.