### PR TITLE
fix: fix MSLShaderInterfaceVariable naming

### DIFF
--- a/spirv_cross/src/wrapper.cpp
+++ b/spirv_cross/src/wrapper.cpp
@@ -110,7 +110,7 @@ extern "C"
     }
 
     ScInternalResult sc_internal_compiler_msl_compile(const ScInternalCompilerBase *compiler, const char **shader,
-                                                      const spirv_cross::MSLShaderInput *p_vat_overrides, const size_t vat_override_count,
+                                                      const spirv_cross::MSLShaderInterfaceVariable *p_vat_overrides, const size_t vat_override_count,
                                                       const spirv_cross::MSLResourceBinding *p_res_overrides, const size_t res_override_count,
                                                       const ScMslConstSamplerMapping *p_const_samplers, const size_t const_sampler_count)
     {

--- a/spirv_cross/src/wrapper.hpp
+++ b/spirv_cross/src/wrapper.hpp
@@ -175,7 +175,7 @@ extern "C"
     ScInternalResult sc_internal_compiler_msl_set_options(const ScInternalCompilerMsl *compiler, const ScMslCompilerOptions *options);
     ScInternalResult sc_internal_compiler_msl_get_is_rasterization_disabled(const ScInternalCompilerMsl *compiler, bool *is_rasterization_disabled);
     ScInternalResult sc_internal_compiler_msl_compile(const ScInternalCompilerBase *compiler, const char **shader,
-                                                      const spirv_cross::MSLShaderInput *p_vat_overrides, const size_t vat_override_count,
+                                                      const spirv_cross::MSLShaderInterfaceVariable *p_vat_overrides, const size_t vat_override_count,
                                                       const spirv_cross::MSLResourceBinding *p_res_overrides, const size_t res_override_count,
                                                       const ScMslConstSamplerMapping *p_const_samplers, const size_t const_sampler_count);
 #endif


### PR DESCRIPTION
`MSLShaderInput` got renamed to `MSLShaderInterfaceVariable` in newer versions of SPIRV-Cross. This is needed to fix the build after updating to latest SPIRV-Cross.

I haven't updated the submodule since it's pointing to your fork but it will need to be updated after merging this.