### PR TITLE
Let C++ API throw exceptions, instead of aborting

### DIFF
--- a/spirv_cross/build.rs
+++ b/spirv_cross/build.rs
@@ -26,10 +26,6 @@ fn main() {
     }
 
     build
-        .flag("-DSPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS")
-        .flag("-DSPIRV_CROSS_WRAPPER_NO_EXCEPTIONS");
-
-    build
         .file("src/wrapper.cpp")
         .file("src/vendor/SPIRV-Cross/spirv_cfg.cpp")
         .file("src/vendor/SPIRV-Cross/spirv_cross.cpp")


### PR DESCRIPTION
Currently, there are some SPIR-V Cross errors that will just print to stderr and abort the program, which can cause a lot of undesired effects. By letting SPIR-V Cross throw esceptions on those cases, these can be catched and returned to Rust as errors instead of program-finishing aborts.